### PR TITLE
Allow multiple parameters through setParameter when creating a Host.

### DIFF
--- a/lib/process.py
+++ b/lib/process.py
@@ -243,6 +243,11 @@ def write_config(params, config_path=None):
         config_path = tempfile.mktemp(prefix="mongo-")
 
     cfg = params.copy()
+    if 'setParameter' in cfg:
+        set_parameters = cfg.pop('setParameter')
+        for key, value in set_parameters.items():
+            cfg['setParameter = ' + key] = value
+
     # fix boolean value
     for key, value in cfg.items():
         if isinstance(value, bool):

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -275,6 +275,18 @@ class HostTestCase(unittest.TestCase):
         self.host.restart()
         self.assertTrue(self.host.is_alive)
 
+    def test_set_parameter(self):
+        cfg = {"setParameter": {"textSearchEnabled": True,
+                                "enableTestCommands": 1}}
+        host = Host(self.mongod, cfg)
+        host.start()
+        c = pymongo.MongoClient(host.hostname)
+        c.foo.bar.insert({"data": "text stuff"})
+        # No Exception.
+        c.foo.bar.ensure_index([("data", pymongo.TEXT)])
+        # No Exception.
+        c.admin.command("sleep", secs=1)
+
     def test_cleanup(self):
         self.host.start(80)
         self.assertTrue(os.path.exists(self.host.cfg['dbpath']))


### PR DESCRIPTION
Addresses #26 

Since Mongo Orchestration could already start mongod with any value for `setParameter`, we should already be able to test SCRAM-SHA-1 with MO. However, the tests in Jenkins also use `setParameter` to turn `enableTestCommands=1`, so these changes allow us to specify more than one parameter to tune with `setParameter`, e.g.:

```
curl -XPOST http://localhost:8889/servers -d'{"procParams": {"setParameter": {"enableTestCommands": 1, "textSearchEnabled": true, etc.}}}'
```
