### PR TITLE
uuid is good enough for resource ids

### DIFF
--- a/lib/replica_sets.py
+++ b/lib/replica_sets.py
@@ -33,7 +33,7 @@ class ReplicaSet(object):
         self.auth_key = rs_params.get('auth_key', None)
         self.login = rs_params.get('login', '')
         self.password = rs_params.get('password', '')
-        self.repl_id = rs_params.get('id', None) or "rs-" + str(uuid4())
+        self.repl_id = rs_params.get('id', None) or str(uuid4())
 
         self.sslParams = rs_params.get('sslParams', {})
         self.kwargs = {}

--- a/lib/sharded_clusters.py
+++ b/lib/sharded_clusters.py
@@ -23,7 +23,7 @@ class ShardedCluster(object):
 
     def __init__(self, params):
         """init configuration acording params"""
-        self.id = params.get('id', None) or 'sh-' + str(uuid4())
+        self.id = params.get('id', None) or str(uuid4())
         self.login = params.get('login', '')
         self.password = params.get('password', '')
         self.auth_key = params.get('auth_key', None)


### PR DESCRIPTION
We don't need the rs/sh prepended part of the id.
