### PR TITLE
scripts/mo can support HTTP/1.1 responses.

### DIFF
--- a/scripts/mo
+++ b/scripts/mo
@@ -44,7 +44,7 @@ function delete {
 }
 
 function code {
-   expr "$1" : '.*HTTP/1.0 \([0-9]*\)'
+   expr "$1" : '.*HTTP/1.[01] \([0-9]*\)'
 }
 
 function usage {


### PR DESCRIPTION
scripts/mo looks for a HTTP/1.0 response to a GET request before making another request to the same endpoint (such as a delete). My curl on Mac OS X uses HTTP/1.1 and gets an HTTP/1.1 response back, too, so doing `scripts/mo <config> stop` doesn't work.
