### PR TITLE
Fix paths to pid file, log file, configurations directory.

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -33,7 +33,9 @@ def update(d, u):
 def preset_merge(data, cluster_type):
     preset = data.get('preset', None)
     if preset is not None:
-        path = os.path.join(os.environ.get("MONGO_ORCHESTRATION_HOME"),
+        base_path = os.environ.get('MONGO_ORCHESTRATION_HOME')
+        parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        path = os.path.join(base_path or parent_dir,
                             'configurations', cluster_type, preset)
         preset_data = {}
         with open(path, "r") as preset_file:

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -10,14 +10,10 @@ from bson import SON
 
 from mongo_orchestration.daemon import Daemon
 
-work_dir = os.path.split(os.path.join(os.getcwd(), __file__))[0]
+work_dir = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
 
 pid_file = os.path.join(work_dir, 'server.pid')
 log_file = os.path.join(work_dir, 'server.log')
-
-# Set MONGO_ORCHESTRATION_HOME to current working directory if unset.
-if not 'MONGO_ORCHESTRATION_HOME' in os.environ:
-    os.environ['MONGO_ORCHESTRATION_HOME'] = work_dir
 
 DEFAULT_PORT = 8889
 


### PR DESCRIPTION
Addresses #117

Changes:
- Do not automatically set `MONGO_ORCHESTRATION_HOME` when unset.
- Use current working directory for pid and log files, or `MONGO_ORCHESTRATION_HOME` if set. Currently these may go into the site-packages directory, and `mongo-orchestration` may require root privileges to run.
- Look in parent directory of `mongo_orchestration` for "configurations" directory, or in `MONGO_ORCHESTRATION_HOME` if set. Currently we're looking in the `mongo_orchestration` package itself.

Basically, `MONGO_ORCHESTRATION_HOME` overrides the path where we look for or put things. Otherwise, we do what makes sense.
