### PR TITLE
Fix some path issues

### DIFF
--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -10,14 +10,10 @@ from bson import SON
 
 from mongo_orchestration.daemon import Daemon
 
-work_dir = os.path.split(os.path.join(os.getcwd(), __file__))[0]
+work_dir = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
 
 pid_file = os.path.join(work_dir, 'server.pid')
 log_file = os.path.join(work_dir, 'server.log')
-
-# Set MONGO_ORCHESTRATION_HOME to current working directory if unset.
-if not 'MONGO_ORCHESTRATION_HOME' in os.environ:
-    os.environ['MONGO_ORCHESTRATION_HOME'] = work_dir
 
 DEFAULT_PORT = 8889
 


### PR DESCRIPTION
Addresses #117

Changes:
- Do not automatically set `MONGO_ORCHESTRATION_HOME` when unset.
- Use current working directory for pid and log files, or `MONGO_ORCHESTRATION_HOME` if set. Currently these may go into the site-packages directory, and `mongo-orchestration` may require root privileges to run.
