### PR TITLE
Remove extraneous calls to logging.basicConfig.

### DIFF
--- a/mongo_orchestration/apps/replica_sets.py
+++ b/mongo_orchestration/apps/replica_sets.py
@@ -26,7 +26,6 @@ from mongo_orchestration.apps import (error_wrap, get_json, Route,
 from mongo_orchestration.common import *
 from mongo_orchestration.replica_sets import ReplicaSets
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/mongo_orchestration/apps/servers.py
+++ b/mongo_orchestration/apps/servers.py
@@ -27,7 +27,6 @@ from mongo_orchestration.common import *
 from mongo_orchestration.errors import RequestError
 from mongo_orchestration.servers import Servers
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/mongo_orchestration/apps/sharded_clusters.py
+++ b/mongo_orchestration/apps/sharded_clusters.py
@@ -26,7 +26,6 @@ from mongo_orchestration.apps import (error_wrap, get_json, Route,
 from mongo_orchestration.common import *
 from mongo_orchestration.sharded_clusters import ShardedClusters
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/mongo_orchestration/container.py
+++ b/mongo_orchestration/container.py
@@ -18,7 +18,6 @@ import logging
 
 from mongo_orchestration.errors import MongoOrchestrationError
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -26,7 +26,6 @@ from mongo_orchestration.replica_sets import ReplicaSets
 from mongo_orchestration.singleton import Singleton
 from pymongo import MongoClient
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Addresses #123 

Since all these files all live together in the mongo_orchestration package now, importing the module can cause one of these (now removed) calls to `basicConfig` to be called before the one that sets up the log file (https://github.com/mongodb/mongo-orchestration/blob/master/mongo_orchestration/server.py#L21). If so, no server.log ever gets created.
