### PR TITLE
Try to use replSetGetConfig command before querying system collection and don't care about 'buildIndexes' property.

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -456,10 +456,7 @@ class ReplicaSet(object):
             cfg_member_info.update(member)
             # Remove attributes we can't check.
             for attr in ('priority', 'votes', 'tags', 'buildIndexes'):
-                try:
-                    cfg_member_info.pop(attr)
-                except KeyError:
-                    pass
+                cfg_member_info.pop(attr, None)
             cfg_member_info['host'] = cfg_member_info['host'].lower()
 
             real_member_info = self.default_params.copy()


### PR DESCRIPTION
Changes:
- Don't wait for `buildIndexes` property in replica set configuration to match some hard-coded default.
- Try to use `replSetGetConfig` command first before querying local.system.replset for replica set configuration.

Mongo Orchestration was assuming that `buildIndexes` was always false. According to the [documentation](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].buildIndexes), that may never have been true. Note that MO never actually configured replica sets with `buildIndexes: false`.
