### PR TITLE
Remove obsolete 'uri' field from all responses.

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -212,8 +212,11 @@ class Server(object):
                 server_info = {}
                 status_info = {}
 
-        logger.debug("return {d}".format(d={"uri": self.hostname, "mongodb_uri": mongodb_uri, "statuses": status_info, "serverInfo": server_info, "procInfo": proc_info}))
-        return {"uri": self.hostname, "mongodb_uri": mongodb_uri, "statuses": status_info, "serverInfo": server_info, "procInfo": proc_info, "orchestration": 'servers'}
+        result = {"mongodb_uri": mongodb_uri, "statuses": status_info,
+                  "serverInfo": server_info, "procInfo": proc_info,
+                  "orchestration": 'servers'}
+        logger.debug("return {result}".format(result=result))
+        return result
 
     @property
     def _is_locked(self):

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -115,7 +115,7 @@ class ShardedCluster(object):
 
     def router_add(self, params):
         """add new router (mongos) into existing configuration"""
-        cfgs = ','.join([Servers().info(item)['uri'] for item in self._configsvrs])
+        cfgs = ','.join([Servers().hostname(item) for item in self._configsvrs])
         params.update({'configdb': cfgs})
         self._routers.append(Servers().create(
             'mongos', params, sslParams=self.sslParams, autostart=True,
@@ -189,7 +189,7 @@ class ShardedCluster(object):
                 params['version'] = self._version
             logger.debug("servers create params: {params}".format(**locals()))
             server_id = Servers().create('mongod', **params)
-            result = self._add(Servers().info(server_id)['uri'], member_id)
+            result = self._add(Servers().hostname(server_id), member_id)
             if result.get('ok', 0) == 1:
                 self._shards[result['shardAdded']] = {'isServer': True, '_id': server_id}
                 # return self._shards[result['shardAdded']]
@@ -242,7 +242,6 @@ class ShardedCluster(object):
                 'shards': self.members,
                 'configsvrs': self.configsvrs,
                 'routers': self.routers,
-                'uri': uri,
                 'mongodb_uri': mongodb_uri,
                 'orchestration': 'sharded_clusters'}
 

--- a/tests/test_sharded_clusters.py
+++ b/tests/test_sharded_clusters.py
@@ -159,15 +159,17 @@ class ShardsTestCase(unittest.TestCase):
         sh_id = self.sh.create(config)
         info = self.sh.info(sh_id)
         self.assertTrue(isinstance(info, dict))
-        for item in ("shards", "configsvrs", "routers", "uri", "mongodb_uri", "orchestration"):
+        for item in ("shards", "configsvrs", "routers",
+                     "mongodb_uri", "orchestration"):
             self.assertTrue(item in info)
 
         self.assertEqual(len(info['shards']), 2)
         self.assertEqual(len(info['configsvrs']), 3)
         self.assertEqual(len(info['routers']), 3)
-        self.assertTrue(info['uri'].find(','))
-        self.assertTrue(info['mongodb_uri'].find(info['uri']))
-        self.assertTrue(info['mongodb_uri'].find('mongodb://') == 0)
+        mongodb_uri = info['mongodb_uri']
+        for router in info['routers']:
+            self.assertIn(Servers().hostname(router['id']), mongodb_uri)
+        self.assertTrue(mongodb_uri.find('mongodb://') == 0)
         self.assertEqual(info['orchestration'], 'sharded_clusters')
 
     def test_configsvrs(self):


### PR DESCRIPTION
Addresses #128 

Changes:
- Remove the `uri` field from all responses.

The `uri` field is redundant with `mongodb_uri`. It's also misleading since it was used to represent the path to another resource previously (before links were introduced).
