### PR TITLE
bind to 127.0.0.1 instead of all interfaces

### DIFF
--- a/mongo_orchestration/configurations/replica_sets/arbiter.json
+++ b/mongo_orchestration/configurations/replica_sets/arbiter.json
@@ -8,6 +8,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -26,6 +27,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -44,6 +46,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/auth.json
+++ b/mongo_orchestration/configurations/replica_sets/auth.json
@@ -14,6 +14,7 @@
                 "nssize": 1, 
                 "port": 27017, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -35,6 +36,7 @@
                 "nssize": 1, 
                 "port": 27018, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -56,6 +58,7 @@
                 "nssize": 1, 
                 "port": 27019, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/basic.json
+++ b/mongo_orchestration/configurations/replica_sets/basic.json
@@ -8,6 +8,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -26,6 +27,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -44,6 +46,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/heap.json
+++ b/mongo_orchestration/configurations/replica_sets/heap.json
@@ -8,6 +8,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {
@@ -27,6 +28,7 @@
                 "nssize": 1,
                 "smallfiles": true,
                 "storageEngine": "heap1",
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {
@@ -45,6 +47,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/ssl.json
+++ b/mongo_orchestration/configurations/replica_sets/ssl.json
@@ -12,6 +12,7 @@
                 "nssize": 1, 
                 "port": 27017, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -33,6 +34,7 @@
                 "nssize": 1, 
                 "port": 27018, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -54,6 +56,7 @@
                 "nssize": 1, 
                 "port": 27019, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/ssl_auth.json
+++ b/mongo_orchestration/configurations/replica_sets/ssl_auth.json
@@ -14,6 +14,7 @@
                 "nssize": 1, 
                 "port": 27017, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -35,6 +36,7 @@
                 "nssize": 1, 
                 "port": 27018, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             }, 
             "rsParams": {
@@ -56,6 +58,7 @@
                 "nssize": 1, 
                 "port": 27019, 
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/replica_sets/wiredtiger.json
+++ b/mongo_orchestration/configurations/replica_sets/wiredtiger.json
@@ -8,6 +8,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {
@@ -27,6 +28,7 @@
                 "nssize": 1,
                 "smallfiles": true,
                 "storageEngine": "wiredtiger",
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {
@@ -45,6 +47,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
+                "bind_ip": "127.0.0.1",
                 "setParameter": {"enableTestCommands": 1}
             },
             "rsParams": {

--- a/mongo_orchestration/configurations/servers/auth.json
+++ b/mongo_orchestration/configurations/servers/auth.json
@@ -11,6 +11,7 @@
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
         "port": 27017,
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }
 }

--- a/mongo_orchestration/configurations/servers/basic.json
+++ b/mongo_orchestration/configurations/servers/basic.json
@@ -4,6 +4,7 @@
         "ipv6": true, 
         "logappend": true,
         "journal": true,
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }
 }

--- a/mongo_orchestration/configurations/servers/clean.json
+++ b/mongo_orchestration/configurations/servers/clean.json
@@ -8,6 +8,7 @@
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
         "port": 27017,
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }
 }

--- a/mongo_orchestration/configurations/servers/heap.json
+++ b/mongo_orchestration/configurations/servers/heap.json
@@ -5,6 +5,7 @@
         "logappend": true,
         "journal": true,
         "storageEngine": "heap1",
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }
 }

--- a/mongo_orchestration/configurations/servers/ssl.json
+++ b/mongo_orchestration/configurations/servers/ssl.json
@@ -8,12 +8,14 @@
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
         "port": 27017,
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }, 
     "sslParams": {
         "sslCAFile": "$SSL_FILES/ca.pem", 
         "sslOnNormalPorts": true, 
         "sslPEMKeyFile": "$SSL_FILES/server.pem", 
+        "bind_ip": "127.0.0.1",
         "sslWeakCertificateValidation": true
     }
 }

--- a/mongo_orchestration/configurations/servers/ssl_auth.json
+++ b/mongo_orchestration/configurations/servers/ssl_auth.json
@@ -11,6 +11,7 @@
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
         "port": 27017,
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }, 
     "sslParams": {

--- a/mongo_orchestration/configurations/servers/wiredtiger.json
+++ b/mongo_orchestration/configurations/servers/wiredtiger.json
@@ -5,6 +5,7 @@
         "logappend": true,
         "journal": true,
         "storageEngine": "wiredtiger",
+        "bind_ip": "127.0.0.1",
         "setParameter": {"enableTestCommands": 1}
     }
 }

--- a/mongo_orchestration/configurations/sharded_clusters/auth.json
+++ b/mongo_orchestration/configurations/sharded_clusters/auth.json
@@ -5,6 +5,7 @@
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
             "port": 27117,
+            "bind_ip": "127.0.0.1",
             "setParameter": {"enableTestCommands": 1}
         }
     ], 
@@ -18,6 +19,7 @@
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
                     "port": 27217,
+                    "bind_ip": "127.0.0.1",
                     "setParameter": {"enableTestCommands": 1}
                 }
             }
@@ -29,6 +31,7 @@
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
                     "port": 27218,
+                    "bind_ip": "127.0.0.1",
                     "setParameter": {"enableTestCommands": 1}
                 }
             }
@@ -39,11 +42,13 @@
         {
             "logpath": "$LOGPATH/router27017.log",
             "port": 27017,
+            "bind_ip": "127.0.0.1",
             "setParameter": {"enableTestCommands": 1}
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
             "port": 27018,
+            "bind_ip": "127.0.0.1",
             "setParameter": {"enableTestCommands": 1}
         }
     ]

--- a/mongo_orchestration/configurations/sharded_clusters/basic.json
+++ b/mongo_orchestration/configurations/sharded_clusters/basic.json
@@ -8,18 +8,30 @@
         {
             "id": "sh01", 
             "shardParams": {
-                "procParams": {"setParameter": {"enableTestCommands": 1}}
+                "procParams": {
+                    "bind_ip": "127.0.0.1",
+                    "setParameter": {"enableTestCommands": 1}
+                }
             }
         }, 
         {
             "id": "sh02", 
             "shardParams": {
-                "procParams": {"setParameter": {"enableTestCommands": 1}}
+                "procParams": {
+                    "bind_ip": "127.0.0.1",
+                    "setParameter": {"enableTestCommands": 1}
+                }
             }
         }
     ], 
     "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
+        {
+            "bind_ip": "127.0.0.1",
+            "setParameter": {"enableTestCommands": 1}
+        },
+        {
+            "bind_ip": "127.0.0.1",
+            "setParameter": {"enableTestCommands": 1}
+        }
     ]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/clean.json
+++ b/mongo_orchestration/configurations/sharded_clusters/clean.json
@@ -3,6 +3,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
+            "bind_ip": "127.0.0.1",
             "port": 27117,
             "setParameter": {"enableTestCommands": 1}
         }
@@ -15,6 +16,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27217,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -26,6 +28,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27218,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -35,11 +38,13 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
+            "bind_ip": "127.0.0.1",
             "port": 27017,
             "setParameter": {"enableTestCommands": 1}
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
+            "bind_ip": "127.0.0.1",
             "port": 27018,
             "setParameter": {"enableTestCommands": 1}
         }

--- a/mongo_orchestration/configurations/sharded_clusters/heap.json
+++ b/mongo_orchestration/configurations/sharded_clusters/heap.json
@@ -7,6 +7,7 @@
             "id": "sh01",
             "shardParams": {
                 "procParams": {
+                    "bind_ip": "127.0.0.1",
                     "storageEngine": "heap1",
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -16,13 +17,20 @@
             "id": "sh02",
             "shardParams": {
                 "procParams": {
+                    "bind_ip": "127.0.0.1",
                     "setParameter": {"enableTestCommands": 1}
                 }
             }
         }
     ],
     "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
+        {"setParameter": {
+            "bind_ip": "127.0.0.1",
+            "enableTestCommands": 1}
+        },
+        {"setParameter": {
+            "bind_ip": "127.0.0.1",
+            "enableTestCommands": 1}
+        }
     ]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/ssl.json
+++ b/mongo_orchestration/configurations/sharded_clusters/ssl.json
@@ -3,6 +3,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
+            "bind_ip": "127.0.0.1",
             "port": 27117,
             "setParameter": {"enableTestCommands": 1}
         }
@@ -15,6 +16,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27217,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -26,6 +28,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27218,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -35,11 +38,13 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
+            "bind_ip": "127.0.0.1",
             "port": 27017,
             "setParameter": {"enableTestCommands": 1}
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
+            "bind_ip": "127.0.0.1",
             "port": 27018,
             "setParameter": {"enableTestCommands": 1}
         }

--- a/mongo_orchestration/configurations/sharded_clusters/ssl_auth.json
+++ b/mongo_orchestration/configurations/sharded_clusters/ssl_auth.json
@@ -4,6 +4,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
+            "bind_ip": "127.0.0.1",
             "port": 27117,
             "setParameter": {"enableTestCommands": 1}
         }
@@ -17,6 +18,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27217,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -28,6 +30,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
+                    "bind_ip": "127.0.0.1",
                     "port": 27218,
                     "setParameter": {"enableTestCommands": 1}
                 }
@@ -38,11 +41,13 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
+            "bind_ip": "127.0.0.1",
             "port": 27017,
             "setParameter": {"enableTestCommands": 1}
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
+            "bind_ip": "127.0.0.1",
             "port": 27018,
             "setParameter": {"enableTestCommands": 1}
         }

--- a/mongo_orchestration/configurations/sharded_clusters/wiredtiger.json
+++ b/mongo_orchestration/configurations/sharded_clusters/wiredtiger.json
@@ -8,6 +8,7 @@
             "shardParams": {
                 "procParams": {
                     "storageEngine": "wiredtiger",
+                    "bind_ip": "127.0.0.1",
                     "setParameter": {"enableTestCommands": 1}
                 }
             }
@@ -16,13 +17,20 @@
             "id": "sh02",
             "shardParams": {
                 "procParams": {
+                    "bind_ip": "127.0.0.1",
                     "setParameter": {"enableTestCommands": 1}
                 }
             }
         }
     ],
     "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
+        {"setParameter":
+            "bind_ip": "127.0.0.1",
+            {"enableTestCommands": 1}
+        },
+        {"setParameter":
+            "bind_ip": "127.0.0.1",
+            {"enableTestCommands": 1}
+        }
     ]
 }


### PR DESCRIPTION
In order for downstream packagers of drivers (like linux distributions) to support testing via mongo-orchestration we must not start servers that globally bind to all interfaces. This is a requirement for the C++ driver (specifically [CXX-383](https://jira.mongodb.org/browse/CXX-383)). @acmorrow can clarify if needed.
