### PR TITLE
remove explicit dependency on pywin32

### DIFF
--- a/mongo_orchestration/daemon.py
+++ b/mongo_orchestration/daemon.py
@@ -20,14 +20,6 @@ import subprocess
 import sys
 import time
 
-have_pywin32 = False
-
-try:
-    from win32process import DETACHED_PROCESS
-    have_pywin32 = True
-except ImportError:
-    pass
-
 from signal import SIGTERM
 
 DEVNULL = open(os.devnull, 'r+b')
@@ -57,11 +49,7 @@ class Daemon(object):
             self.daemonize_posix()
 
     def daemonize_win32(self):
-        if have_pywin32:
-            pid = subprocess.Popen(sys.argv + ["--no-fork"], creationflags=DETACHED_PROCESS, shell=True).pid
-        else:
-            print("No pywin32! Can't daemonize")
-            sys.exit(1)
+        pid = subprocess.Popen(sys.argv + ["--no-fork"], creationflags=0x00000008, shell=True).pid
 
         with open(self.pidfile, 'w+') as fd:
             fd.write("%s\n" % pid)

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,7 @@
 import os
 import sys
 
-if os.name == 'nt':
-    extra_deps = ['pywin32']
-else:
-    extra_deps = []
-
+extra_deps = []
 extra_test_deps = []
 if sys.version_info[:2] == (2, 6):
     extra_deps.append('argparse')


### PR DESCRIPTION
Turns out we can hardcode 0x00000008 as per Microsoft docs:

http://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx

You apparently can't install pywin32 via pip so this relieves a huge headache for us on MCI when we were trying to jam MO into a virtual env without getting it polluted with system site packages. Already in production on C++ driver Windows tests.
