### PR TITLE
Use the ip from the most recent HTTP request when setting up mongo processes.

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -19,6 +19,10 @@ import json
 import os
 import copy
 
+DEFAULT_BIND = os.environ.get('MO_HOST', 'localhost')
+DEFAULT_PORT = int(os.environ.get('MO_PORT', '8889'))
+DEFAULT_SERVER = 'cherrypy'
+
 
 def update(d, u):
     for k, v in u.items():

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -8,6 +8,8 @@ import sys
 
 from bson import SON
 
+from mongo_orchestration.common import (
+    DEFAULT_BIND, DEFAULT_PORT, DEFAULT_SERVER)
 from mongo_orchestration.daemon import Daemon
 from mongo_orchestration.servers import Server
 
@@ -15,10 +17,6 @@ work_dir = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
 
 pid_file = os.path.join(work_dir, 'server.pid')
 log_file = os.path.join(work_dir, 'server.log')
-
-DEFAULT_BIND = 'localhost'
-DEFAULT_PORT = 8889
-DEFAULT_SERVER = 'cherrypy'
 
 import logging
 logging.basicConfig(level=logging.DEBUG, filename=log_file, filemode='w')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,8 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import socket
 import sys
 import time
+
+PORT = int(os.environ.get('MO_PORT', '8889'))
+HOSTNAME = socket.getaddrinfo(
+    os.environ.get('MO_HOST', '127.0.0.1'), PORT,
+    socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)[-1][-1][0]
+
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -29,7 +29,7 @@ import mongo_orchestration.process as process
 from mongo_orchestration.errors import TimeoutError
 from nose.plugins.attrib import attr
 
-from tests import unittest, SkipTest
+from tests import unittest, SkipTest, HOSTNAME
 
 
 @attr('process')
@@ -38,7 +38,7 @@ from tests import unittest, SkipTest
 class PortPoolTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.hostname = process.HOSTNAME
+        self.hostname = HOSTNAME
         self.pp = process.PortPool()
         self.pp.change_range(min_port=1025, max_port=1080)
         self.sockets = {}
@@ -52,7 +52,7 @@ class PortPoolTestCase(unittest.TestCase):
             self.sockets[port].close()
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind((process.HOSTNAME, port))
+        s.bind((HOSTNAME, port))
         s.listen(max_connection)
         self.sockets[port] = s
 
@@ -141,7 +141,7 @@ class PortPoolTestCase(unittest.TestCase):
 @attr('test')
 class ProcessTestCase(unittest.TestCase):
     def setUp(self):
-        self.hostname = process.HOSTNAME
+        self.hostname = HOSTNAME
         self.s = None
         self.executable = sys.executable
         self.pp = process.PortPool(min_port=1025, max_port=2000)
@@ -165,7 +165,7 @@ class ProcessTestCase(unittest.TestCase):
             self.sockets[port].close()
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind((process.HOSTNAME, port))
+        s.bind((HOSTNAME, port))
         s.listen(max_connection)
         self.sockets[port] = s
 

--- a/tests/test_replica_sets.py
+++ b/tests/test_replica_sets.py
@@ -26,9 +26,9 @@ sys.path.insert(0, '../')
 
 from mongo_orchestration.replica_sets import ReplicaSet, ReplicaSets
 from mongo_orchestration.servers import Servers
-from mongo_orchestration.process import PortPool, HOSTNAME
+from mongo_orchestration.process import PortPool
 from nose.plugins.attrib import attr
-from tests import unittest, assert_eventually
+from tests import unittest, assert_eventually, HOSTNAME
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/tests/test_sharded_clusters.py
+++ b/tests/test_sharded_clusters.py
@@ -29,9 +29,9 @@ from mongo_orchestration import set_releases
 from mongo_orchestration.sharded_clusters import ShardedCluster, ShardedClusters
 from mongo_orchestration.replica_sets import ReplicaSets
 from mongo_orchestration.servers import Servers
-from mongo_orchestration.process import PortPool, HOSTNAME
+from mongo_orchestration.process import PortPool
 from nose.plugins.attrib import attr
-from tests import unittest, SkipTest
+from tests import unittest, SkipTest, HOSTNAME
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Addresses #151 

Changes:
- Use `request.urlparts` to find the host to which the request is sent, and use that host to set up mongo.
- Use IP addresses, rather than symbolic hostnames, when setting up mongo processes. These are also returned in `mongodb_uri` now.
