### PR TITLE
Selectively turn on enableTestCommands automatically.

### DIFF
--- a/mongo_orchestration/configurations/replica_sets/arbiter.json
+++ b/mongo_orchestration/configurations/replica_sets/arbiter.json
@@ -7,8 +7,7 @@
                 "journal": true,
                 "noprealloc": true, 
                 "nssize": 1, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -25,8 +24,7 @@
                 "journal": true,
                 "noprealloc": true, 
                 "nssize": 1, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -43,8 +41,7 @@
                 "journal": true,
                 "noprealloc": true,
                 "nssize": 1,
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/auth.json
+++ b/mongo_orchestration/configurations/replica_sets/auth.json
@@ -13,8 +13,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27017, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -34,8 +33,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27018, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -55,8 +53,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27019, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/basic.json
+++ b/mongo_orchestration/configurations/replica_sets/basic.json
@@ -7,8 +7,7 @@
                 "journal": true,
                 "noprealloc": true, 
                 "nssize": 1, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -25,8 +24,7 @@
                 "journal": true,
                 "noprealloc": true, 
                 "nssize": 1, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -43,8 +41,7 @@
                 "journal": true,
                 "noprealloc": true, 
                 "nssize": 1, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/clean.json
+++ b/mongo_orchestration/configurations/replica_sets/clean.json
@@ -11,8 +11,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27017, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -32,8 +31,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27018, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -53,8 +51,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27019, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/in_memory.json
+++ b/mongo_orchestration/configurations/replica_sets/in_memory.json
@@ -7,8 +7,7 @@
                 "journal": true,
                 "noprealloc": true,
                 "nssize": 1,
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "priority": 99,
@@ -26,8 +25,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
-                "storageEngine": "inMemoryExperiment",
-                "setParameter": {"enableTestCommands": 1}
+                "storageEngine": "inMemoryExperiment"
             },
             "rsParams": {
                 "priority": 1.1,
@@ -44,8 +42,7 @@
                 "journal": true,
                 "noprealloc": true,
                 "nssize": 1,
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/ssl.json
+++ b/mongo_orchestration/configurations/replica_sets/ssl.json
@@ -11,8 +11,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27017, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -32,8 +31,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27018, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -53,8 +51,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27019, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/ssl_auth.json
+++ b/mongo_orchestration/configurations/replica_sets/ssl_auth.json
@@ -13,8 +13,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27017, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 99,
@@ -34,8 +33,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27018, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             }, 
             "rsParams": {
                 "priority": 1.1,
@@ -55,8 +53,7 @@
                 "noprealloc": true, 
                 "nssize": 1, 
                 "port": 27019, 
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/replica_sets/wiredtiger.json
+++ b/mongo_orchestration/configurations/replica_sets/wiredtiger.json
@@ -7,8 +7,7 @@
                 "journal": true,
                 "noprealloc": true,
                 "nssize": 1,
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "priority": 99,
@@ -26,8 +25,7 @@
                 "noprealloc": true,
                 "nssize": 1,
                 "smallfiles": true,
-                "storageEngine": "wiredtiger",
-                "setParameter": {"enableTestCommands": 1}
+                "storageEngine": "wiredtiger"
             },
             "rsParams": {
                 "priority": 1.1,
@@ -44,8 +42,7 @@
                 "journal": true,
                 "noprealloc": true,
                 "nssize": 1,
-                "smallfiles": true,
-                "setParameter": {"enableTestCommands": 1}
+                "smallfiles": true
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/servers/auth.json
+++ b/mongo_orchestration/configurations/servers/auth.json
@@ -10,7 +10,6 @@
         "logappend": true, 
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
-        "port": 27017,
-        "setParameter": {"enableTestCommands": 1}
+        "port": 27017
     }
 }

--- a/mongo_orchestration/configurations/servers/basic.json
+++ b/mongo_orchestration/configurations/servers/basic.json
@@ -1,9 +1,8 @@
 {
     "name": "mongod",
     "procParams": {
-        "ipv6": true, 
+        "ipv6": true,
         "logappend": true,
-        "journal": true,
-        "setParameter": {"enableTestCommands": 1}
+        "journal": true
     }
 }

--- a/mongo_orchestration/configurations/servers/clean.json
+++ b/mongo_orchestration/configurations/servers/clean.json
@@ -7,7 +7,6 @@
         "logappend": true, 
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
-        "port": 27017,
-        "setParameter": {"enableTestCommands": 1}
+        "port": 27017
     }
 }

--- a/mongo_orchestration/configurations/servers/in_memory.json
+++ b/mongo_orchestration/configurations/servers/in_memory.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "logappend": true,
         "journal": true,
-        "storageEngine": "inMemoryExperiment",
-        "setParameter": {"enableTestCommands": 1}
+        "storageEngine": "inMemoryExperiment"
     }
 }

--- a/mongo_orchestration/configurations/servers/ssl.json
+++ b/mongo_orchestration/configurations/servers/ssl.json
@@ -7,8 +7,7 @@
         "logappend": true, 
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
-        "port": 27017,
-        "setParameter": {"enableTestCommands": 1}
+        "port": 27017
     }, 
     "sslParams": {
         "sslCAFile": "$SSL_FILES/ca.pem", 

--- a/mongo_orchestration/configurations/servers/ssl_auth.json
+++ b/mongo_orchestration/configurations/servers/ssl_auth.json
@@ -10,8 +10,7 @@
         "logappend": true, 
         "logpath": "$LOGPATH/mongod.log", 
         "journal": true,
-        "port": 27017,
-        "setParameter": {"enableTestCommands": 1}
+        "port": 27017
     }, 
     "sslParams": {
         "sslCAFile": "$SSL_FILES/ca.pem", 

--- a/mongo_orchestration/configurations/servers/wiredtiger.json
+++ b/mongo_orchestration/configurations/servers/wiredtiger.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "logappend": true,
         "journal": true,
-        "storageEngine": "wiredtiger",
-        "setParameter": {"enableTestCommands": 1}
+        "storageEngine": "wiredtiger"
     }
 }

--- a/mongo_orchestration/configurations/sharded_clusters/auth.json
+++ b/mongo_orchestration/configurations/sharded_clusters/auth.json
@@ -4,8 +4,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
-            "port": 27117,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27117
         }
     ], 
     "id": "shard_cluster_1", 
@@ -17,8 +16,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
-                    "port": 27217,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27217
                 }
             }
         }, 
@@ -28,8 +26,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
-                    "port": 27218,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27218
                 }
             }
         }
@@ -38,13 +35,11 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
-            "port": 27017,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27017
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
-            "port": 27018,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27018
         }
     ]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/basic.json
+++ b/mongo_orchestration/configurations/sharded_clusters/basic.json
@@ -1,25 +1,8 @@
 {
-    "configsvrs": [
-        {
-            "setParameter": {"enableTestCommands": 1}
-        }
-    ],
+    "configsvrs": [{}],
     "shards": [
-        {
-            "id": "sh01", 
-            "shardParams": {
-                "procParams": {"setParameter": {"enableTestCommands": 1}}
-            }
-        }, 
-        {
-            "id": "sh02", 
-            "shardParams": {
-                "procParams": {"setParameter": {"enableTestCommands": 1}}
-            }
-        }
+        {"id": "sh01"}, 
+        {"id": "sh02"}
     ], 
-    "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
-    ]
+    "routers": [{}, {}]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/clean.json
+++ b/mongo_orchestration/configurations/sharded_clusters/clean.json
@@ -3,8 +3,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
-            "port": 27117,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27117
         }
     ], 
     "id": "shard_cluster_1", 
@@ -15,8 +14,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
-                    "port": 27217,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27217
                 }
             }
         }, 
@@ -26,8 +24,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
-                    "port": 27218,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27218
                 }
             }
         }
@@ -35,13 +32,11 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
-            "port": 27017,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27017
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
-            "port": 27018,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27018
         }
     ]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/in_memory.json
+++ b/mongo_orchestration/configurations/sharded_clusters/in_memory.json
@@ -1,28 +1,15 @@
 {
-    "configsvrs": [
-        {"setParameter": {"enableTestCommands": 1}}
-    ],
+    "configsvrs": [{}],
     "shards": [
         {
             "id": "sh01",
             "shardParams": {
                 "procParams": {
-                    "storageEngine": "inMemoryExperiment",
-                    "setParameter": {"enableTestCommands": 1}
+                    "storageEngine": "inMemoryExperiment"
                 }
             }
         },
-        {
-            "id": "sh02",
-            "shardParams": {
-                "procParams": {
-                    "setParameter": {"enableTestCommands": 1}
-                }
-            }
-        }
+        {"id": "sh02"}
     ],
-    "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
-    ]
+    "routers": [{}, {}]
 }

--- a/mongo_orchestration/configurations/sharded_clusters/ssl.json
+++ b/mongo_orchestration/configurations/sharded_clusters/ssl.json
@@ -3,8 +3,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
-            "port": 27117,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27117
         }
     ], 
     "id": "shard_cluster_1", 
@@ -15,8 +14,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
-                    "port": 27217,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27217
                 }
             }
         }, 
@@ -26,8 +24,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
-                    "port": 27218,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27218
                 }
             }
         }
@@ -35,13 +32,11 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
-            "port": 27017,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27017
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
-            "port": 27018,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27018
         }
     ], 
     "sslParams": {

--- a/mongo_orchestration/configurations/sharded_clusters/ssl_auth.json
+++ b/mongo_orchestration/configurations/sharded_clusters/ssl_auth.json
@@ -4,8 +4,7 @@
         {
             "dbpath": "$DBPATH/db27117",
             "logpath": "$LOGPATH/configsvr27117.log",
-            "port": 27117,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27117
         }
     ], 
     "id": "shard_cluster_1", 
@@ -17,8 +16,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27217",
                     "logpath": "$LOGPATH/sh01.log",
-                    "port": 27217,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27217
                 }
             }
         }, 
@@ -28,8 +26,7 @@
                 "procParams": {
                     "dbpath": "$DBPATH/db27218",
                     "logpath": "$LOGPATH/sh02.log",
-                    "port": 27218,
-                    "setParameter": {"enableTestCommands": 1}
+                    "port": 27218
                 }
             }
         }
@@ -38,13 +35,11 @@
     "routers": [
         {
             "logpath": "$LOGPATH/router27017.log",
-            "port": 27017,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27017
         }, 
         {
             "logpath": "$LOGPATH/router27018.log",
-            "port": 27018,
-            "setParameter": {"enableTestCommands": 1}
+            "port": 27018
         }
     ],
     "sslParams": {

--- a/mongo_orchestration/configurations/sharded_clusters/wiredtiger.json
+++ b/mongo_orchestration/configurations/sharded_clusters/wiredtiger.json
@@ -1,28 +1,15 @@
 {
-    "configsvrs": [
-        {"setParameter": {"enableTestCommands": 1}}
-    ],
+    "configsvrs": [{}],
     "shards": [
         {
             "id": "sh01",
             "shardParams": {
                 "procParams": {
-                    "storageEngine": "wiredtiger",
-                    "setParameter": {"enableTestCommands": 1}
+                    "storageEngine": "wiredtiger"
                 }
             }
         },
-        {
-            "id": "sh02",
-            "shardParams": {
-                "procParams": {
-                    "setParameter": {"enableTestCommands": 1}
-                }
-            }
-        }
+        {"id": "sh02"}
     ],
-    "routers": [
-        {"setParameter": {"enableTestCommands": 1}},
-        {"setParameter": {"enableTestCommands": 1}}
-    ]
+    "routers": [{}, {}]
 }

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -18,7 +18,9 @@ import errno
 import logging
 import os
 import platform
+import re
 import stat
+import subprocess
 import tempfile
 import time
 
@@ -40,6 +42,11 @@ class Server(object):
     # default params for all mongo instances
     mongod_default = {"noprealloc": True, "smallfiles": True, "oplogSize": 100}
 
+    # regular expression matching MongoDB versions
+    version_patt = re.compile(
+        '(?:db version v|MongoS version |mongos db version )'
+        '(?P<version>(\d+\.)+\d+)')
+
     def __init_db(self, dbpath):
         if not dbpath:
             dbpath = tempfile.mkdtemp(prefix="mongo-")
@@ -57,6 +64,13 @@ class Server(object):
     def __init_logpath(self, log_path):
         if log_path and not os.path.exists(os.path.dirname(log_path)):
             os.makedirs(log_path)
+
+    def __init_test_commands(self, config):
+        """Conditionally enable test commands in the Server's config file."""
+        if self.version >= (2, 4):
+            params = config.get('setParameter', {})
+            params['enableTestCommands'] = 1
+            config['setParameter'] = params
 
     def __init_mongod(self, params, ssl):
         cfg = self.mongod_default.copy()
@@ -81,6 +95,8 @@ class Server(object):
         if 'port' not in cfg:
             cfg['port'] = process.PortPool().port(check=True)
 
+        self.__init_test_commands(cfg)
+
         return process.write_config(cfg), cfg
 
     def __init_mongos(self, params, ssl):
@@ -95,6 +111,8 @@ class Server(object):
 
         if 'port' not in cfg:
             cfg['port'] = process.PortPool().port(check=True)
+
+        self.__init_test_commands(cfg)
 
         return process.write_config(cfg), cfg
 
@@ -145,6 +163,17 @@ class Server(object):
             except:
                 pass
         return c
+
+    @property
+    def version(self):
+        """Get the version of MongoDB that this Server runs as a tuple."""
+        command = (self.name, '--version')
+        stdout, _ = subprocess.Popen(
+            command, stdout=subprocess.PIPE).communicate()
+        first_line = stdout.split('\n')[0]
+        match = re.search(self.version_patt, first_line)
+        version_string = match.group('version')
+        return tuple(map(int, version_string.split('.')))
 
     def freeze(self, timeout=60):
         """Run `replSetFreeze` on this server.


### PR DESCRIPTION
This is another possible option for resolving #152 that doesn't rely on having another set of configuration files.

I've tested this with various versions of mongod and mongos from 2.0 - 2.8, and it works nicely on all of them.