### PR TITLE
Show replica set member state when returning info about replica set as a...

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -316,7 +316,12 @@ class ReplicaSet(object):
         """return list of members information"""
         result = list()
         for member in self.run_command(command="replSetGetStatus", is_eval=False)['members']:
-            result.append({"_id": member['_id'], "host": member["name"], "server_id": self._servers.id_by_hostname(member["name"])})
+            result.append({
+                "_id": member['_id'],
+                "host": member["name"],
+                "server_id": self._servers.id_by_hostname(member["name"]),
+                "state": member['state']
+            })
         return result
 
     def primary(self):


### PR DESCRIPTION
... whole.

This makes it easier to figure out what member is primary, secondary, or an arbiter without having to send a second request. The "state" field corresponds to one of these: http://docs.mongodb.org/manual/reference/replica-states/. See also http://docs.mongodb.org/manual/reference/command/replSetGetStatus/.