### PR TITLE
Don't specify mmapv1-specific options by default or with wiredtiger pres...

### DIFF
--- a/mongo_orchestration/configurations/replica_sets/wiredtiger.json
+++ b/mongo_orchestration/configurations/replica_sets/wiredtiger.json
@@ -22,9 +22,6 @@
                 "ipv6": true,
                 "nohttpinterface": true,
                 "journal": true,
-                "noprealloc": true,
-                "nssize": 1,
-                "smallfiles": true,
                 "storageEngine": "wiredtiger"
             },
             "rsParams": {

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -40,7 +40,7 @@ class Server(object):
     """Class Server represents behaviour of  mongo instances """
 
     # default params for all mongo instances
-    mongod_default = {"noprealloc": True, "smallfiles": True, "oplogSize": 100}
+    mongod_default = {"oplogSize": 100}
 
     # regular expression matching MongoDB versions
     version_patt = re.compile(


### PR DESCRIPTION
...et.

I'll also change the jenkins scripts to fix failures like this: https://jenkins.10gen.com/job/mongo-python-driver-storage-engines-v2.8/label=linux64,storage_engine=wiredtiger/45/console