### PR TITLE
Allow specifying ids for servers within a replica set/sharded cluster.

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -60,9 +60,13 @@ class ReplicaSet(object):
         if not not self.sslParams:
             self.kwargs['ssl'] = True
 
-        config = {"_id": self.repl_id, "members": [
-                  self.member_create(member, index) for index, member in enumerate(rs_params.get('members', {}))
-                  ]}
+        config = {
+            "_id": self.repl_id,
+            "members": [
+                self.member_create(member, index)
+                for index, member in enumerate(rs_params.get('members', {}))
+            ]
+        }
         logger.debug("replica config: {config}".format(**locals()))
         if not self.repl_init(config):
             self.cleanup()
@@ -242,12 +246,13 @@ class ReplicaSet(object):
         return member config
         """
         member_config = params.get('rsParams', {})
+        server_id = params.pop('server_id')
         proc_params = {'replSet': self.repl_id}
         proc_params.update(params.get('procParams', {}))
 
         server_id = self._servers.create(
             'mongod', proc_params, self.sslParams, self.auth_key,
-            version=self._version)
+            version=self._version, server_id=server_id)
         member_config.update({"_id": member_id,
                               "host": self._servers.hostname(server_id)})
         return member_config

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -82,11 +82,13 @@ class ShardedCluster(object):
         """create and start config servers"""
         self._configsvrs = []
         for cfg in params:
+            server_id = cfg.pop('server_id', None)
             cfg.update({'configsvr': True})
             self._configsvrs.append(Servers().create(
                 'mongod', cfg,
                 sslParams=self.sslParams, autostart=True,
-                auth_key=self.auth_key, version=self._version))
+                auth_key=self.auth_key, version=self._version,
+                server_id=server_id))
 
     def __len__(self):
         return len(self._shards)
@@ -118,10 +120,11 @@ class ShardedCluster(object):
     def router_add(self, params):
         """add new router (mongos) into existing configuration"""
         cfgs = ','.join([Servers().hostname(item) for item in self._configsvrs])
+        server_id = params.pop('server_id', None)
         params.update({'configdb': cfgs})
         self._routers.append(Servers().create(
             'mongos', params, sslParams=self.sslParams, autostart=True,
-            auth_key=self.auth_key, version=self._version))
+            auth_key=self.auth_key, version=self._version, server_id=server_id))
         return {'id': self._routers[-1], 'hostname': Servers().hostname(self._routers[-1])}
 
     def connection(self):

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -175,6 +175,8 @@ class ShardedCluster(object):
         if 'members' in params:
             # is replica set
             rs_params = params.copy()
+            # Turn 'rs_id' -> 'id', to be consistent with 'server_id' below.
+            rs_params['id'] = rs_params.pop('rs_id', None)
             rs_params.update({'auth_key': self.auth_key})
             rs_params.update({'sslParams': self.sslParams})
             if self.login and self.password:


### PR DESCRIPTION
Addresses #164 

Changes:
- Allow specifying an id for each Server to be created within a repilca set. This makes it easy to figure out what the URI will be for a given replica set member, for example.
- Allow providing an id to routers and configsvrs within a sharded cluster in a similar manner to the above.
- If providing an id for a replica set shard, the id should be provided in the `rs_id` field, rather than `id`. This is more consistent with `server_id` when specifying an id for a standalone shard.