### PR TITLE
Add 'mongodb_auth_uri' field to Server/ReplicaSet/ShardedCluster info + tests.

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -65,6 +65,21 @@ class BaseModel(object):
         params.pop("clusterAuthMode", None)
         return params
 
+    def mongodb_auth_uri(self, hosts):
+        """Get a connection string with all info necessary to authenticate."""
+        parts = ['mongodb://']
+        if self.login:
+            parts.append(self.login)
+            if self.password:
+                parts.append(':' + self.password)
+            parts.append('@')
+        parts.append(hosts + '/')
+        if self.login:
+            parts.append('?authSource=' + self.auth_source)
+            if self.x509_extra_user:
+                parts.append('&authMechanism=MONGODB-X509')
+        return ''.join(parts)
+
     def _add_users(self, db):
         """Add given user, and extra x509 user if necessary."""
         if self.x509_extra_user:

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -247,6 +247,8 @@ class Server(BaseModel):
         result = {"mongodb_uri": mongodb_uri, "statuses": status_info,
                   "serverInfo": server_info, "procInfo": proc_info,
                   "orchestration": 'servers'}
+        if self.login:
+            result['mongodb_auth_uri'] = self.mongodb_auth_uri(self.hostname)
         logger.debug("return {result}".format(result=result))
         return result
 

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -344,12 +344,15 @@ class ShardedCluster(BaseModel):
         """return info about configuration"""
         uri = ','.join(x['hostname'] for x in self.routers)
         mongodb_uri = 'mongodb://' + uri
-        return {'id': self.id,
-                'shards': self.members,
-                'configsvrs': self.configsvrs,
-                'routers': self.routers,
-                'mongodb_uri': mongodb_uri,
-                'orchestration': 'sharded_clusters'}
+        result = {'id': self.id,
+                  'shards': self.members,
+                  'configsvrs': self.configsvrs,
+                  'routers': self.routers,
+                  'mongodb_uri': mongodb_uri,
+                  'orchestration': 'sharded_clusters'}
+        if self.login:
+            result['mongodb_auth_uri'] = self.mongodb_auth_uri(uri)
+        return result
 
     def cleanup(self):
         """cleanup configuration: stop and remove all servers"""


### PR DESCRIPTION
Addresses #157 

This field only shows up when there's actually a user as whom to authenticate.