### PR TITLE
PyMongo 3 compatibility.

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -103,6 +103,12 @@ class BaseModel(object):
         db.add_user(**secondary_login)
 
 
+def connected(client):
+    # Await connection in PyMongo 3.0.
+    client.admin.command('ismaster')
+    return client
+
+
 def update(d, u):
     for k, v in u.items():
         if isinstance(v, collections.Mapping):

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -436,7 +436,6 @@ class ReplicaSet(BaseModel):
                         servers, socketTimeoutMS=20000,
                         w='majority', fsync=True, **self.kwargs)
                     connected(c)
-                    c.admin.command('ismaster')
                     self._authenticate_client(c)
                     return c
             except (pymongo.errors.PyMongoError):

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 import pymongo
 
 from mongo_orchestration.common import (
-    BaseModel, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
+    BaseModel, connected, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
 from mongo_orchestration.singleton import Singleton
 from mongo_orchestration.container import Container
 from mongo_orchestration.errors import ReplicaSetError
@@ -425,6 +425,7 @@ class ReplicaSet(BaseModel):
                         servers, replicaSet=self.repl_id,
                         read_preference=read_preference, socketTimeoutMS=20000,
                         w='majority', fsync=True, **self.kwargs)
+                    connected(c)
                     if c.primary:
                         self._authenticate_client(c)
                         return c
@@ -434,6 +435,8 @@ class ReplicaSet(BaseModel):
                     c = pymongo.MongoClient(
                         servers, socketTimeoutMS=20000,
                         w='majority', fsync=True, **self.kwargs)
+                    connected(c)
+                    c.admin.command('ismaster')
                     self._authenticate_client(c)
                     return c
             except (pymongo.errors.PyMongoError):

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -29,7 +29,7 @@ import pymongo
 
 from mongo_orchestration import process
 from mongo_orchestration.common import (
-    BaseModel, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
+    BaseModel, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT, connected)
 from mongo_orchestration.errors import ServersError, TimeoutError
 from mongo_orchestration.singleton import Singleton
 from mongo_orchestration.container import Container
@@ -157,6 +157,7 @@ class Server(BaseModel):
     def connection(self):
         """return authenticated connection"""
         c = pymongo.MongoClient(self.hostname, fsync=True, **self.kwargs)
+        connected(c)
         if not self.is_mongos and self.login and not self.restart_required:
             db = c[self.auth_source]
             if self.x509_extra_user:

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -26,7 +26,8 @@ import pymongo
 
 sys.path.insert(0, '../')
 
-from mongo_orchestration.common import DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT
+from mongo_orchestration.common import (
+    connected, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
 from mongo_orchestration.servers import Server, Servers
 from mongo_orchestration.process import PortPool
 from tests import (
@@ -310,11 +311,11 @@ class ServerTestCase(unittest.TestCase):
 
     def test_reset(self):
         self.server.stop()
-        self.assertRaises(pymongo.errors.ConnectionFailure,
-                          pymongo.MongoClient, self.server.hostname)
+        with self.assertRaises(pymongo.errors.ConnectionFailure):
+            connected(pymongo.MongoClient(self.server.hostname))
         self.server.reset()
         # No ConnectionFailure.
-        pymongo.MongoClient(self.server.hostname)
+        connected(pymongo.MongoClient(self.server.hostname))
 
 
 class ServerSSLTestCase(SSLTestCase):
@@ -381,11 +382,11 @@ class ServerSSLTestCase(SSLTestCase):
         self.server = Server('mongod', {}, ssl_params)
         self.server.start()
         # Server should require SSL.
-        self.assertRaises(pymongo.errors.ConnectionFailure,
-                          pymongo.MongoClient, self.server.hostname)
+        with self.assertRaises(pymongo.errors.ConnectionFailure):
+            connected(pymongo.MongoClient, self.server.hostname)
         # Doesn't raise with certificate provided.
-        pymongo.MongoClient(
-            self.server.hostname, ssl_certfile=certificate('client.pem'))
+        connected(pymongo.MongoClient(
+            self.server.hostname, ssl_certfile=certificate('client.pem')))
 
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):


### PR DESCRIPTION
MongoClient() no longer raises if it can't connect, must attempt an operation to know if the server is available.