### PR TITLE
Use first release in config file as default.

### DIFF
--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -54,7 +54,7 @@ def read_env():
     try:
         # read config
         with open(cli_args.config, 'r') as fd:
-            config = json.loads(fd.read(), object_hook=SON)
+            config = json.loads(fd.read(), object_pairs_hook=SON)
         if not 'releases' in config:
             print("No releases defined in %s" % cli_args.config)
             sys.exit(1)

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -1,11 +1,17 @@
 #!/usr/bin/python
 # coding=utf-8
 import argparse
-import json
 import logging
 import os
 import signal
 import sys
+
+try:
+    # Need simplejson for the object_pairs_hook option in Python 2.6.
+    import simplejson as json
+except ImportError:
+    # Python 2.7+.
+    import json
 
 from bson import SON
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ extra_deps = []
 extra_test_deps = []
 if sys.version_info[:2] == (2, 6):
     extra_deps.append('argparse')
+    extra_deps.append('simplejson')
     extra_test_deps.append('unittest2')
     extra_opts['test_suite'] = 'unittest2.collector'
 


### PR DESCRIPTION
To my surprise and, I expect, yours, object_hook doesn't preserve order but object_pairs_hook does.