### PR TITLE
Easier console debugging with --no-fork.

### DIFF
--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -176,7 +176,7 @@ def repair_mongo(name, dbpath):
     return
 
 
-def mprocess(name, config_path, port=None, timeout=180):
+def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):
     """start 'name' process with params from config_path.
     Args:
         name - process name or path
@@ -184,6 +184,7 @@ def mprocess(name, config_path, port=None, timeout=180):
         port - process's port
         timeout - specify how long, in seconds, a command can take before times out.
                   if timeout <=0 - doesn't wait for complete start process
+        silence_stdout - if True (default), redirect stdout to /dev/null
     return tuple (Popen object, host) if process started, return (None, None) if not
     """
 
@@ -200,9 +201,10 @@ def mprocess(name, config_path, port=None, timeout=180):
     host = "{ip}:{port}".format(ip=_ip(), port=port)
     try:
         logger.debug("execute process: {cmd}".format(**locals()))
-        proc = subprocess.Popen(cmd,
-                                stdout=DEVNULL,
-                                stderr=subprocess.STDOUT)
+        proc = subprocess.Popen(
+            cmd,
+            stdout=DEVNULL if silence_stdout else None,
+            stderr=subprocess.STDOUT)
 
         if proc.poll() is not None:
             logger.debug("process is not alive")

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -112,9 +112,16 @@ class MyDaemon(Daemon):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG, filename=log_file, filemode='w')
-    daemon = MyDaemon(pid_file, timeout=5, stdout=sys.stdout)
     args = read_env()
+    if args.no_fork:
+        logging.basicConfig(level=logging.DEBUG)
+        Server.silence_stdout = False
+    else:
+        logging.basicConfig(level=logging.DEBUG, filename=log_file,
+                            filemode='w')
+        Server.silence_stdout = True
+
+    daemon = MyDaemon(pid_file, timeout=5, stdout=sys.stdout)
     daemon.set_args(args)
     # Set default bind ip for mongo processes using argument from --bind.
     Server.mongod_default['bind_ip'] = args.bind

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -40,6 +40,9 @@ logger = logging.getLogger(__name__)
 class Server(BaseModel):
     """Class Server represents behaviour of  mongo instances """
 
+    # redirect stdout to /dev/null?
+    silence_stdout = True
+
     # default params for all mongo instances
     mongod_default = {"oplogSize": 100}
 
@@ -283,7 +286,9 @@ class Server(BaseModel):
                 # repair if needed
                 process.repair_mongo(self.name, self.cfg['dbpath'])
 
-            self.proc, self.hostname = process.mprocess(self.name, self.config_path, self.cfg.get('port', None), timeout)
+            self.proc, self.hostname = process.mprocess(
+                self.name, self.config_path, self.cfg.get('port', None),
+                timeout, self.silence_stdout)
             self.pid = self.proc.pid
             logger.debug("pid={pid}, hostname={hostname}".format(pid=self.pid, hostname=self.hostname))
             self.host = self.hostname.split(':')[0]


### PR DESCRIPTION
Don't silence logging or mongod output if foregrounded. Good for debugging why a mongod won't start.