### PR TITLE
Support mixed-version clusters.

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -277,6 +277,7 @@ class ReplicaSet(BaseModel):
         """
         member_config = params.get('rsParams', {})
         server_id = params.pop('server_id', None)
+        version = params.pop('version', self._version)
         proc_params = {'replSet': self.repl_id}
         proc_params.update(params.get('procParams', {}))
         # Make sure that auth isn't set the first time we start the servers.
@@ -287,7 +288,7 @@ class ReplicaSet(BaseModel):
             name='mongod',
             procParams=proc_params,
             sslParams=self.sslParams,
-            version=self._version,
+            version=version,
             server_id=server_id
         )
         member_config.update({"_id": member_id,


### PR DESCRIPTION
This works but I found it extremely hard to test. I think the existing unittests need a lot of work to be able to test this so I fronted Orchestration with Conduction and wrote a jstest:

https://gist.github.com/ajdavis/79265dd22b1318640219

Examples:
```
POST to /v1/servers:
{"preset": "basic.json", "version": "master"}

POST to /v1/replica_sets:
{
  "preset": "basic.json",
  "version": "master",
  "members": [
            {},
            {"version": "30-release"},
            {"version": "26-release"}]}}

POST to /v1/sharded_clusters:

{
  "preset": "basic.json",
  "id": "my_id",
  "shards": [
    {
      "id": "sh-rs-01",
      "shardParams": {
        "version": "master",
        "members": [{"version": "30-release"}, {}]
      }
    },
    {
      "id": "sh-rs-02",
      "shardParams": {
        "version": "30-release",
        "members": [{}, {"version": "master"}]}}]}
```