### PR TITLE
Explicitly pass ssl.CERT_NONE when creating MongoClients that use SSL.

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -18,6 +18,7 @@ import collections
 import copy
 import json
 import os
+import ssl
 import stat
 import tempfile
 import time
@@ -38,6 +39,11 @@ DEFAULT_CLIENT_CERT = os.path.join(
     'lib',
     'client.pem'
 )
+DEFAULT_SSL_OPTIONS = {
+    'ssl': True,
+    'ssl_certfile': DEFAULT_CLIENT_CERT,
+    'ssl_cert_reqs': ssl.CERT_NONE
+}
 
 
 class BaseModel(object):

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 import pymongo
 
 from mongo_orchestration.common import (
-    BaseModel, connected, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
+    BaseModel, connected, DEFAULT_SUBJECT, DEFAULT_SSL_OPTIONS)
 from mongo_orchestration.singleton import Singleton
 from mongo_orchestration.container import Container
 from mongo_orchestration.errors import ReplicaSetError
@@ -62,8 +62,7 @@ class ReplicaSet(BaseModel):
         self.x509_extra_user = False
 
         if self.sslParams:
-            self.kwargs['ssl'] = True
-            self.kwargs['ssl_certfile'] = DEFAULT_CLIENT_CERT
+            self.kwargs.update(DEFAULT_SSL_OPTIONS)
 
         members = rs_params.get('members', {})
         config = {"_id": self.repl_id, "members": [

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -29,7 +29,7 @@ import pymongo
 
 from mongo_orchestration import process
 from mongo_orchestration.common import (
-    BaseModel, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT, connected)
+    BaseModel, DEFAULT_SUBJECT, DEFAULT_SSL_OPTIONS, connected)
 from mongo_orchestration.errors import ServersError, TimeoutError
 from mongo_orchestration.singleton import Singleton
 from mongo_orchestration.container import Container
@@ -139,8 +139,7 @@ class Server(BaseModel):
         self.restart_required = self.login or self.auth_key
 
         if self.ssl_params:
-            self.kwargs['ssl'] = True
-            self.kwargs['ssl_certfile'] = DEFAULT_CLIENT_CERT
+            self.kwargs.update(DEFAULT_SSL_OPTIONS)
 
         proc_name = os.path.split(name)[1].lower()
         procParams.update(sslParams)

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -20,7 +20,7 @@ import tempfile
 from uuid import uuid4
 
 from mongo_orchestration.common import (
-    BaseModel, DEFAULT_SUBJECT, DEFAULT_CLIENT_CERT)
+    BaseModel, DEFAULT_SUBJECT, DEFAULT_SSL_OPTIONS)
 from mongo_orchestration.container import Container
 from mongo_orchestration.errors import ShardedClusterError
 from mongo_orchestration.servers import Servers
@@ -54,8 +54,7 @@ class ShardedCluster(BaseModel):
         self.x509_extra_user = False
 
         if self.sslParams:
-            self.kwargs['ssl'] = True
-            self.kwargs['ssl_certfile'] = DEFAULT_CLIENT_CERT
+            self.kwargs.update(DEFAULT_SSL_OPTIONS)
 
         configsvr_configs = params.get('configsvrs', [{}])
         self.__init_configsvr(configsvr_configs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ import sys
 import time
 
 from mongo_orchestration import set_releases
-from mongo_orchestration.servers import Servers
+from mongo_orchestration.servers import Server, Servers
 
 PORT = int(os.environ.get('MO_PORT', '8889'))
 HOSTNAME = os.environ.get('MO_HOST', 'localhost')
@@ -32,6 +32,9 @@ TEST_RELEASES = (
 # Set up the default mongo binaries to use from MONGOBIN.
 set_releases(*TEST_RELEASES)
 
+# Turn off journal and preallocation for tests.
+Server.mongod_default['nojournal'] = True
+Server.mongod_default['noprealloc'] = True
 
 SSL_ENABLED = False
 SERVER_VERSION = (2, 6)

--- a/tests/test_replica_sets.py
+++ b/tests/test_replica_sets.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import logging
-import os
+import ssl
 import sys
 import operator
 import time
@@ -629,6 +629,9 @@ class ReplicaSetTestCase(unittest.TestCase):
 
 class ReplicaSetSSLTestCase(SSLTestCase):
 
+    def tearDown(self):
+        self.repl.cleanup()
+
     def test_ssl_auth(self):
         if SERVER_VERSION < (2, 4):
             raise SkipTest("Need to be able to set 'authenticationMechanisms' "
@@ -657,13 +660,15 @@ class ReplicaSetSSLTestCase(SSLTestCase):
 
         # Should create an extra user. No raise on authenticate.
         client = pymongo.MongoClient(
-            self.repl.primary(), ssl_certfile=DEFAULT_CLIENT_CERT)
+            self.repl.primary(), ssl_certfile=DEFAULT_CLIENT_CERT,
+            ssl_cert_reqs=ssl.CERT_NONE)
         client['$external'].authenticate(
             DEFAULT_SUBJECT, mechanism='MONGODB-X509')
 
         # Should create the user we requested. No raise on authenticate.
         client = pymongo.MongoClient(
-            self.repl.primary(), ssl_certfile=certificate('client.pem'))
+            self.repl.primary(), ssl_certfile=certificate('client.pem'),
+            ssl_cert_reqs=ssl.CERT_NONE)
         client['$external'].authenticate(
             TEST_SUBJECT, mechanism='MONGODB-X509')
 
@@ -686,7 +691,8 @@ class ReplicaSetSSLTestCase(SSLTestCase):
 
         # Should create the user we requested. No raise on authenticate.
         client = pymongo.MongoClient(
-            self.repl.primary(), ssl_certfile=certificate('client.pem'))
+            self.repl.primary(), ssl_certfile=certificate('client.pem'),
+            ssl_cert_reqs=ssl.CERT_NONE)
         client.admin.authenticate('luke', 'ekul')
         # This should be the only user.
         self.assertEqual(len(client.admin.command('usersInfo')['users']), 1)
@@ -713,7 +719,8 @@ class ReplicaSetSSLTestCase(SSLTestCase):
 
         # This shouldn't raise.
         connected(pymongo.MongoClient(
-            self.repl.primary(), ssl_certfile=certificate('client.pem')))
+            self.repl.primary(), ssl_certfile=certificate('client.pem'),
+            ssl_cert_reqs=ssl.CERT_NONE))
 
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):

--- a/tests/test_sharded_clusters.py
+++ b/tests/test_sharded_clusters.py
@@ -17,6 +17,7 @@
 import logging
 import operator
 import pymongo
+import ssl
 import sys
 import time
 
@@ -627,13 +628,16 @@ class ShardSSLTestCase(SSLTestCase):
 
         # Should create an extra user. No raise on authenticate.
         host = self.sh.router['hostname']
-        client = pymongo.MongoClient(host, ssl_certfile=DEFAULT_CLIENT_CERT)
+        client = pymongo.MongoClient(
+            host, ssl_certfile=DEFAULT_CLIENT_CERT,
+            ssl_cert_reqs=ssl.CERT_NONE)
         client['$external'].authenticate(
             DEFAULT_SUBJECT, mechanism='MONGODB-X509')
 
         # Should create the user we requested. No raise on authenticate.
         client = pymongo.MongoClient(
-            host, ssl_certfile=certificate('client.pem'))
+            host, ssl_certfile=certificate('client.pem'),
+            ssl_cert_reqs=ssl.CERT_NONE)
         client['$external'].authenticate(TEST_SUBJECT, mechanism='MONGODB-X509')
 
     def test_scram_with_ssl(self):
@@ -661,7 +665,8 @@ class ShardSSLTestCase(SSLTestCase):
         # Should create the user we requested. No raise on authenticate.
         host = self.sh.router['hostname']
         client = pymongo.MongoClient(
-            host, ssl_certfile=certificate('client.pem'))
+            host, ssl_certfile=certificate('client.pem'),
+            ssl_cert_reqs=ssl.CERT_NONE)
         client.admin.authenticate('luke', 'ekul')
         # This should be the only user.
         self.assertEqual(len(client.admin.command('usersInfo')['users']), 1)
@@ -689,7 +694,8 @@ class ShardSSLTestCase(SSLTestCase):
             connected(pymongo.MongoClient(host))
         # This shouldn't raise.
         connected(
-            pymongo.MongoClient(host, ssl_certfile=certificate('client.pem')))
+            pymongo.MongoClient(host, ssl_certfile=certificate('client.pem'),
+                                ssl_cert_reqs=ssl.CERT_NONE))
 
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):


### PR DESCRIPTION
Fixes #188 