### PR TITLE
Don't automatically use 'majority' write concern when adding users to…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license="http://www.apache.org/licenses/LICENSE-2.0.html",
     platforms=['any'],
     url='https://github.com/10gen/mongo-orchestration',
-    install_requires=['pymongo>=3.0',
+    install_requires=['pymongo>=3.0.2',
                       'bottle>=0.12.7',
                       'CherryPy>=3.5.0'] + extra_deps,
     tests_require=['coverage>=3.5'] + extra_test_deps,


### PR DESCRIPTION
… sharded clusters, since this will fail if replication isn't enabled (standalone shards, config servers).

Fixes issues like http://jenkins.bci.10gen.cc:8080/job/mongo-python-driver-v2.9-auth/label=linux64,mongodb_configuration=sharded,mongodb_server=22-release,python_language_version=2.7/lastBuild/console