### PR TITLE
Add presets for mmapv1 storage engine.

### DIFF
--- a/mongo_orchestration/configurations/replica_sets/allengines.json
+++ b/mongo_orchestration/configurations/replica_sets/allengines.json
@@ -1,0 +1,50 @@
+{
+    "members": [
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "mmapv1",
+                "noprealloc": true,
+                "nssize": 1,
+                "smallfiles": true
+            },
+            "rsParams": {
+                "priority": 99,
+                "tags": {
+                    "ordinal": "one",
+                    "dc": "ny",
+                    "engine": "mmapv1"
+                }
+            }
+        },
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "wiredTiger"
+            },
+            "rsParams": {
+                "priority": 1.1,
+                "tags": {
+                    "ordinal": "two",
+                    "dc": "pa",
+                    "engine": "wiredTiger"
+                }
+            }
+        },
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "wiredTiger"
+            },
+            "rsParams": {
+                "arbiterOnly": true
+            }
+        }
+    ]
+}

--- a/mongo_orchestration/configurations/replica_sets/mmapv1.json
+++ b/mongo_orchestration/configurations/replica_sets/mmapv1.json
@@ -1,0 +1,54 @@
+{
+    "members": [
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "mmapv1",
+                "noprealloc": true,
+                "nssize": 1,
+                "smallfiles": true
+            },
+            "rsParams": {
+                "priority": 99,
+                "tags": {
+                    "ordinal": "one",
+                    "dc": "ny"
+                }
+            }
+        },
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "mmapv1",
+                "noprealloc": true,
+                "nssize": 1,
+                "smallfiles": true
+            },
+            "rsParams": {
+                "priority": 1.1,
+                "tags": {
+                    "ordinal": "two",
+                    "dc": "pa"
+                }
+            }
+        },
+        {
+            "procParams": {
+                "ipv6": true,
+                "nohttpinterface": true,
+                "journal": true,
+                "storageEngine": "mmapv1",
+                "noprealloc": true,
+                "nssize": 1,
+                "smallfiles": true
+            },
+            "rsParams": {
+                "arbiterOnly": true
+            }
+        }
+    ]
+}

--- a/mongo_orchestration/configurations/replica_sets/wiredtiger.json
+++ b/mongo_orchestration/configurations/replica_sets/wiredtiger.json
@@ -5,9 +5,7 @@
                 "ipv6": true,
                 "nohttpinterface": true,
                 "journal": true,
-                "noprealloc": true,
-                "nssize": 1,
-                "smallfiles": true
+                "storageEngine": "wiredTiger"
             },
             "rsParams": {
                 "priority": 99,
@@ -37,9 +35,7 @@
                 "ipv6": true,
                 "nohttpinterface": true,
                 "journal": true,
-                "noprealloc": true,
-                "nssize": 1,
-                "smallfiles": true
+                "storageEngine": "wiredTiger"
             },
             "rsParams": {
                 "arbiterOnly": true

--- a/mongo_orchestration/configurations/servers/mmapv1.json
+++ b/mongo_orchestration/configurations/servers/mmapv1.json
@@ -1,0 +1,9 @@
+{
+    "name": "mongod",
+    "procParams": {
+        "ipv6": true,
+        "logappend": true,
+        "journal": true,
+        "storageEngine": "mmapv1"
+    }
+}

--- a/mongo_orchestration/configurations/sharded_clusters/mmapv1.json
+++ b/mongo_orchestration/configurations/sharded_clusters/mmapv1.json
@@ -1,0 +1,15 @@
+{
+    "configsvrs": [{}],
+    "shards": [
+        {
+            "id": "sh01",
+            "shardParams": {
+                "procParams": {
+                    "storageEngine": "mmapv1"
+                }
+            }
+        },
+        {"id": "sh02"}
+    ],
+    "routers": [{}, {}]
+}


### PR DESCRIPTION
Adding mmapv1 presets, since wiredTiger is the default storage engine starting in 3.1.4. These are identical copies of the wiredtiger presets, except that they use mmapv1 as the storage engine explicitly.