### PR TITLE
Provide path to log files for failed process in error message (#198).

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -21,7 +21,10 @@ import os
 import ssl
 import stat
 import tempfile
-import time
+
+WORK_DIR = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
+PID_FILE = os.path.join(WORK_DIR, 'server.pid')
+LOG_FILE = os.path.join(WORK_DIR, 'server.log')
 
 DEFAULT_BIND = os.environ.get('MO_HOST', 'localhost')
 DEFAULT_PORT = int(os.environ.get('MO_PORT', '8889'))

--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -220,7 +220,7 @@ def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):
         proc_alive(proc) and time.sleep(3)  # wait while process stoped
         message = ("Could not connect to process during "
                    "{timeout} seconds".format(timeout=timeout))
-        raise TimeoutError(errno.ETIMEDOUT, message)
+        raise TimeoutError(message, errno.ETIMEDOUT)
     return (proc, host)
 
 

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 import argparse
 import logging
-import os
 import signal
 import sys
 
@@ -18,14 +17,10 @@ from bson import SON
 from mongo_orchestration import __version__
 from mongo_orchestration.common import (
     BaseModel,
-    DEFAULT_BIND, DEFAULT_PORT, DEFAULT_SERVER, DEFAULT_SOCKET_TIMEOUT)
+    DEFAULT_BIND, DEFAULT_PORT, DEFAULT_SERVER, DEFAULT_SOCKET_TIMEOUT,
+    PID_FILE, LOG_FILE)
 from mongo_orchestration.daemon import Daemon
 from mongo_orchestration.servers import Server
-
-work_dir = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
-
-pid_file = os.path.join(work_dir, 'server.pid')
-log_file = os.path.join(work_dir, 'server.log')
 
 
 def read_env():
@@ -128,11 +123,11 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
         Server.silence_stdout = False
     else:
-        logging.basicConfig(level=logging.DEBUG, filename=log_file,
+        logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE,
                             filemode='w')
         Server.silence_stdout = True
 
-    daemon = MyDaemon(pid_file, timeout=5, stdout=sys.stdout)
+    daemon = MyDaemon(PID_FILE, timeout=5, stdout=sys.stdout)
     daemon.set_args(args)
     # Set default bind ip for mongo processes using argument from --bind.
     Server.mongod_default['bind_ip'] = args.bind

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -309,7 +309,17 @@ class Server(BaseModel):
                     "Server did not respond to 'isMaster' after %d attempts."
                     % timeout)
         except (OSError, TimeoutError):
-            logger.exception("Could not start Server.")
+            logpath = self.cfg.get('logpath')
+            if logpath:
+                # Copy the server logs into the mongo-orchestration logs.
+                logger.error(
+                    "Could not start Server. Please find server log below.\n"
+                    "=====================================================")
+                with open(logpath) as lp:
+                    logger.error(lp.read())
+            else:
+                logger.exception(
+                    'Could not start Server, and no logpath was provided!')
             reraise(TimeoutError,
                     'Could not start Server. '
                     'Please check server log located in ' +

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -29,7 +29,8 @@ import pymongo
 
 from mongo_orchestration import process
 from mongo_orchestration.common import (
-    BaseModel, DEFAULT_SUBJECT, DEFAULT_SSL_OPTIONS, connected)
+    BaseModel, DEFAULT_SUBJECT, DEFAULT_SSL_OPTIONS, connected, LOG_FILE)
+from mongo_orchestration.compat import reraise
 from mongo_orchestration.errors import ServersError, TimeoutError
 from mongo_orchestration.singleton import Singleton
 from mongo_orchestration.container import Container
@@ -309,7 +310,12 @@ class Server(BaseModel):
                     % timeout)
         except (OSError, TimeoutError):
             logger.exception("Could not start Server.")
-            raise
+            reraise(TimeoutError,
+                    'Could not start Server. '
+                    'Please check server log located in ' +
+                    self.cfg.get('logpath', '<no logpath given>') +
+                    ' or the mongo-orchestration log in ' +
+                    LOG_FILE + ' for more details.')
         if self.restart_required:
             if self.login:
                 # Add users to the appropriate database.


### PR DESCRIPTION
This will add paths to the log files for the failed process and mongo-orchestration itself when a process fails to start. Is this better, @bjori ? https://github.com/10gen/mongo-orchestration/compare/10gen:master...llvtt:logs-in-error-msg?expand=1#diff-db1689184526eae1aafd7c25bd1cfc03R314