### PR TITLE
Update Exception handling from auth failures against replica sets.

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -414,10 +414,10 @@ class ReplicaSet(BaseModel):
                 else:
                     db.authenticate(
                         self.login, self.password)
-            except:
+            except Exception:
                 logger.exception(
-                    "Could not authenticate to %s:%d as %s/%s"
-                    % (client.host, client.port, self.login, self.password))
+                    "Could not authenticate to %s as %s/%s"
+                    % (','.join(client.nodes), self.login, self.password))
                 raise
 
     def connection(self, hostname=None, read_preference=pymongo.ReadPreference.PRIMARY, timeout=300):


### PR DESCRIPTION
Prevent confusing error messages like this: http://jenkins.bci.10gen.cc:8080/job/mongo-java-driver-test-3.x/299/jdk=HotSpot6,label=linux64,mongodb_configuration=replica_set,mongodb_option=auth,mongodb_server=30-release,mongodb_ssl=nossl/console