### PR TITLE
Search whole "mongod --version" output, not 1st line.

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -191,8 +191,7 @@ class Server(BaseModel):
             command = (self.name, '--version')
             stdout, _ = subprocess.Popen(
                 command, stdout=subprocess.PIPE).communicate()
-            first_line = str(stdout).split('\n')[0]
-            match = re.search(self.version_patt, first_line)
+            match = re.search(self.version_patt, str(stdout))
             version_string = match.group('version')
             self.__version = tuple(map(int, version_string.split('.')))
         return self.__version


### PR DESCRIPTION
On Windows mongod.exe --version can log "Hotfix KB2731284 or later
update is not installed" before printing its version. Parse the whole
output, therefore, not just the first line.