### PR TITLE
Print CreateProcess errors on win32

### DIFF
--- a/mongo_orchestration/daemon.py
+++ b/mongo_orchestration/daemon.py
@@ -49,7 +49,10 @@ class Daemon(object):
             return self.daemonize_posix()
 
     def daemonize_win32(self):
-        pid = subprocess.Popen(sys.argv + ["--no-fork"], creationflags=0x00000008, shell=True).pid
+        DETACHED_PROCESS = 0x00000008
+        pid = subprocess.Popen(sys.argv + ["--no-fork"],
+                               creationflags=DETACHED_PROCESS, shell=True,
+                               stderr=sys.stderr, stdout=sys.stdout).pid
 
         with open(self.pidfile, 'w+') as fd:
             fd.write("%s\n" % pid)


### PR DESCRIPTION
Clarifies a magic number and doesn't suppress output if CreateProcess fails. I found, for example, that if the "mongo_orchestration" script isn't installed, CreateProcess fails silently and daemonization times out mysteriously. With this change in place, however, we get an error:

```
$ python mongo_orchestration/server.py  -f ../orchestration.config -e default start --socket-timeout-ms=60000 --bind=127.0.0.1 -s wsgiref
'mongo_orchestration' is not recognized as an internal or external command,
operable program or batch file.
```
