### PR TITLE
Raise an Exception if we can't determine the version of a mongo process.

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -191,7 +191,12 @@ class Server(BaseModel):
             command = (self.name, '--version')
             stdout, _ = subprocess.Popen(
                 command, stdout=subprocess.PIPE).communicate()
-            match = re.search(self.version_patt, str(stdout))
+            version_output = str(stdout)
+            match = re.search(self.version_patt, version_output)
+            if match is None:
+                raise ServersError(
+                    'Could not determine version of %s from string: %s'
+                    % (self.name, version_output))
             version_string = match.group('version')
             self.__version = tuple(map(int, version_string.split('.')))
         return self.__version


### PR DESCRIPTION
We're having trouble parsing the version of mongo processes on Evergreen, but we don't know why: https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_windows_64_vs2015_nativessl_integration_test_latest_ssl_028fe4d2b2911886d302b5f2b26ace5aa050ca1b_16_05_27_16_50_07/0?type=T#L269