### PR TITLE
BUILD-1873 Don't install CherryPy 7.1 on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Requires
 -  `Python 2.6, 2.7, or >= 3.2 <http://www.python.org/download/>`__
 -  `bottle >= 0.12.7 <https://pypi.python.org/pypi/bottle>`__
 -  `PyMongo >= 3.0.2 <https://pypi.python.org/pypi/pymongo>`__
--  `CherryPy >= 3.5.0 <http://www.cherrypy.org/>`__
+-  `CherryPy >= 3.5.0, < 7.1 <http://www.cherrypy.org/>`__
 -  `argparse >= 1.2.1 <https://pypi.python.org/pypi/argparse>`__ (Python 2.6 only)
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     url='https://github.com/10gen/mongo-orchestration',
     install_requires=['pymongo>=3.0.2',
                       'bottle>=0.12.7',
-                      'CherryPy>=3.5.0'] + extra_deps,
+                      'CherryPy>=3.5.0,<7.1'] + extra_deps,
     tests_require=['coverage>=3.5'] + extra_test_deps,
     packages=find_packages(exclude=('tests',)),
     package_data={


### PR DESCRIPTION
CherryPy 7.1 fails to install on Windows (https://evergreen.mongodb.com/task/evergreen_packer_windows64_vs2015_build_06dcd5beb7beeec8f21c6df1c8d324ae4d00fce8_16_07_25_20_28_51). We should keep the CherryPy version below 7.1 for now.