### PR TITLE
Remove uses of map for python 3 compatibility

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -353,7 +353,7 @@ class ReplicaSet(BaseModel):
             # Can't call serverStatus on arbiter when running with auth enabled.
             # (SERVER-5479)
             if self.login or self.auth_key:
-                arbiter_ids = map(lambda member: member['_id'], self.arbiters())
+                arbiter_ids = [member['_id'] for member in self.arbiters()]
                 if member_id in arbiter_ids:
                     result['rsInfo'] = {
                         'arbiterOnly': True, 'secondary': False, 'primary': False}

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -332,7 +332,8 @@ class ShardedCluster(BaseModel):
             rs_params.update({'sslParams': self.sslParams})
 
             rs_params['version'] = params.pop('version', self._version)
-            rs_params['members'] = map(self._strip_auth, rs_params['members'])
+            rs_params['members'] = [
+                self._strip_auth(params) for params in rs_params['members']]
             rs_id = ReplicaSets().create(rs_params)
             members = ReplicaSets().members(rs_id)
             cfgs = rs_id + r"/" + ','.join([item['host'] for item in members])

--- a/tests/test_replica_sets.py
+++ b/tests/test_replica_sets.py
@@ -604,7 +604,7 @@ class ReplicaSetTestCase(unittest.TestCase):
         self.repl = ReplicaSet(self.repl_cfg)
 
         server_ids = [m['server_id'] for m in self.repl.members()]
-        all_hosts = map(Servers().hostname, server_ids)
+        all_hosts = [Servers().hostname(server_id) for server_id in server_ids]
 
         # Shut down all members of the ReplicaSet.
         for server_id in server_ids:


### PR DESCRIPTION
In python 3 `map` returns an iterator. This causes a problem for sharded clusters because the `rs_params['members']` field is assumed to be a `list` and is iterated over multiple times. 

Removed the other two uses of `map` in favor of list comprehensions to not promote the use of `map` in the future.