### PR TITLE
Include timestamps in logs by default

### DIFF
--- a/mongo_orchestration/apps/servers.py
+++ b/mongo_orchestration/apps/servers.py
@@ -30,7 +30,7 @@ from mongo_orchestration.common import *
 from mongo_orchestration.errors import RequestError
 from mongo_orchestration.servers import Servers
 
-logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -27,6 +27,8 @@ PID_FILE = os.path.join(WORK_DIR, 'server.pid')
 LOG_FILE = os.path.join(WORK_DIR, 'server.log')
 TMP_DIR = os.environ.get('MONGO_ORCHESTRATION_TMP')
 
+LOGGING_FORMAT = '%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s'
+
 DEFAULT_BIND = os.environ.get('MO_HOST', 'localhost')
 DEFAULT_PORT = int(os.environ.get('MO_PORT', '8889'))
 DEFAULT_SERVER = 'cherrypy'

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -22,7 +22,7 @@ from mongo_orchestration import __version__
 from mongo_orchestration.common import (
     BaseModel,
     DEFAULT_BIND, DEFAULT_PORT, DEFAULT_SERVER, DEFAULT_SOCKET_TIMEOUT,
-    PID_FILE, LOG_FILE)
+    PID_FILE, LOG_FILE, LOGGING_FORMAT)
 from mongo_orchestration.daemon import Daemon
 from mongo_orchestration.servers import Server
 
@@ -159,7 +159,8 @@ def main():
     # Silence STDOUT from mongo processes if MO is running as a deamon.
     Server.silence_stdout = not args.no_fork
     # Log both to STDOUT and the log file.
-    logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE)
+    logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE,
+                        format=LOGGING_FORMAT)
     log = logging.getLogger(__name__)
 
     daemon = MyDaemon(os.path.abspath(args.pidfile), timeout=5,


### PR DESCRIPTION
Resolves #223.

Logs now include timestamps like so:
```
2017-02-15 17:01:06,694 [DEBUG] mongo_orchestration.replica_sets:268 - command result: ...
```