### PR TITLE
Bug fix: STARTUP (0) is not an acceptable state

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -552,7 +552,7 @@ class ReplicaSet(BaseModel):
 
     def check_member_state(self):
         """Verify that all RS members have an acceptable state."""
-        bad_states = (3, 4, 5, 6, 9)
+        bad_states = (0, 3, 4, 5, 6, 9)
         try:
             rs_status = self.run_command('replSetGetStatus')
             bad_members = [member for member in rs_status['members']


### PR DESCRIPTION
This prevents mongo-orchestration from replying while a node is in the STARTUP state. See https://github.com/mongodb-labs/mongo-connector/pull/659.