### PR TITLE
Use json_util.dumps to encode all responses

### DIFF
--- a/mongo_orchestration/apps/__init__.py
+++ b/mongo_orchestration/apps/__init__.py
@@ -47,9 +47,9 @@ def setup_versioned_routes(routes, version=None):
 def send_result(code, result=None):
     response.content_type = None
     if result is not None and 200 <= code < 300:
-        # Use json.dumps instead of json_util.dumps to only encode
-        # non JSON serializable BSON types with json_util.
-        result = json.dumps(result, default=json_util.default)
+        # Use json_util.dumps in case the result contains non JSON
+        # serializable BSON types.
+        result = json_util.dumps(result)
         response.content_type = "application/json"
 
     logger.debug("send_result({code})".format(**locals()))

--- a/mongo_orchestration/apps/__init__.py
+++ b/mongo_orchestration/apps/__init__.py
@@ -17,6 +17,8 @@ import logging
 import sys
 import traceback
 
+from bson import json_util
+
 from collections import namedtuple
 
 from bottle import route, response
@@ -45,7 +47,9 @@ def setup_versioned_routes(routes, version=None):
 def send_result(code, result=None):
     response.content_type = None
     if result is not None and 200 <= code < 300:
-        result = json.dumps(result)
+        # Use json.dumps instead of json_util.dumps to only encode
+        # non JSON serializable BSON types with json_util.
+        result = json.dumps(result, default=json_util.default)
         response.content_type = "application/json"
 
     logger.debug("send_result({code})".format(**locals()))

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -274,16 +274,7 @@ class Server(BaseModel):
         if self.hostname and self.cfg.get('port', None):
             try:
                 c = self.connection
-                server_info_raw = c.server_info()
-                # Do add the raw command response because it might contain
-                # non JSON serializable BSON types.
-                whitelisted_keys = set([
-                    'bits', 'gitVersion', 'version', 'versionArray',
-                    'openssl', 'modules',  'debug', 'maxBsonObjectSize',
-                    'javascriptEngine', 'storageEngines'])
-                for field in server_info_raw:
-                    if field in whitelisted_keys:
-                        server_info[field] = server_info_raw[field]
+                server_info = c.server_info()
                 logger.debug("server_info: {server_info}".format(**locals()))
                 mongodb_uri = 'mongodb://' + self.hostname
                 status_info = {"primary": c.is_primary, "mongos": c.is_mongos, "locked": c.is_locked}

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -274,10 +274,16 @@ class Server(BaseModel):
         if self.hostname and self.cfg.get('port', None):
             try:
                 c = self.connection
-                server_info = c.server_info()
-                # Remove $gleStats because it contains BSON types that are not
-                # JSON serializable.
-                server_info.pop('$gleStats', None)
+                server_info_raw = c.server_info()
+                # Do add the raw command response because it might contain
+                # non JSON serializable BSON types.
+                whitelisted_keys = set([
+                    'bits', 'gitVersion', 'version', 'versionArray',
+                    'openssl', 'modules',  'debug', 'maxBsonObjectSize',
+                    'javascriptEngine', 'storageEngines'])
+                for field in server_info_raw:
+                    if field in whitelisted_keys:
+                        server_info[field] = server_info_raw[field]
                 logger.debug("server_info: {server_info}".format(**locals()))
                 mongodb_uri = 'mongodb://' + self.hostname
                 status_info = {"primary": c.is_primary, "mongos": c.is_mongos, "locked": c.is_locked}


### PR DESCRIPTION
This change prevents MO from responding with the raw `buildInfo` command response which might contain BSON types that are not JSON serializable. 

Related to https://github.com/10gen/mongo-orchestration/pull/222 and http://jira.mongodb.org/browse/SERVER-27773.