### PR TITLE
Do not run currentOp due to SERVER-30084.

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -278,7 +278,7 @@ class Server(BaseModel):
                 server_info = c.server_info()
                 logger.debug("server_info: {server_info}".format(**locals()))
                 mongodb_uri = 'mongodb://' + self.hostname
-                status_info = {"primary": c.is_primary, "mongos": c.is_mongos, "locked": c.is_locked}
+                status_info = {"primary": c.is_primary, "mongos": c.is_mongos}
                 logger.debug("status_info: {status_info}".format(**locals()))
             except (pymongo.errors.AutoReconnect, pymongo.errors.OperationFailure, pymongo.errors.ConnectionFailure):
                 server_info = {}


### PR DESCRIPTION
This change works around https://jira.mongodb.org/browse/SERVER-30084. PyMongo's `is_locked`  uses currentOp which causes the latest build of the server to crash. The "locked" field is unused anyway so removing seems fine.