### PR TITLE
Reduce isMaster waiting time from 2.5 hours to 3 minutes.

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -326,17 +326,18 @@ class Server(BaseModel):
             self.port = int(self.hostname.split(':')[1])
 
             # Wait for Server to respond to isMaster.
-            for i in range(timeout):
+            # Only try 6 times, each ConnectionFailure is 30 seconds.
+            max_attempts = 6
+            for i in range(max_attempts):
                 try:
                     self.run_command('isMaster')
                     break
                 except pymongo.errors.ConnectionFailure:
                     logger.exception('isMaster command failed:')
-                    time.sleep(0.1)
             else:
                 raise TimeoutError(
                     "Server did not respond to 'isMaster' after %d attempts."
-                    % timeout)
+                    % max_attempts)
         except (OSError, TimeoutError):
             logpath = self.cfg.get('logpath')
             if logpath:


### PR DESCRIPTION
After this change, one will get this helpful traceback after 3 minutes instead of 2.5 hours (way too long to wait in Evergreen):
```python
Traceback (most recent call last):
  File "/Users/shane/launch.py", line 276, in <module>
    cluster.start()
  File "/Users/shane/launch.py", line 127, in start
    response = self._make_post_request()
  File "/Users/shane/launch.py", line 95, in _make_post_request
    "Error sending POST to cluster: %s" % (ret.text,))
RuntimeError: Error sending POST to cluster: Traceback (most recent call last):
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/__init__.py", line 66, in wrap
    return f(*arg, **kwd)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/servers.py", line 83, in host_create
    result = _host_create(data)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/servers.py", line 52, in _host_create
    params.get('version', ''))
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 461, in create
    server.start(timeout)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 358, in start
    LOG_FILE + ' for more details.')
  File "<string>", line 2, in reraise
TimeoutError: Could not start Server. Please check server log located in /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-EUY6FY/mongod.log or the mongo-orchestration log in /Users/shane/mongo-orchestration/server.log for more details.
```

Even better, mongo-orchestration will copy the failed server's log file to it's own:
```

2017-07-26 10:40:02,113 [ERROR] mongo_orchestration.servers:336 - isMaster command failed:
Traceback (most recent call last):
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 333, in start
    self.run_command('isMaster')
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 256, in run_command
    result = getattr(self.connection.admin, mode)(command, name, **d)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 186, in connection
    connected(c)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/common.py", line 133, in connected
    client.admin.command('ismaster')
  File "/Users/shane/git/mongo-orchestration/venv-python2.6/lib/python2.6/site-packages/pymongo/database.py", line 491, in command
    with client._socket_for_reads(read_preference) as (sock_info, slave_ok):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/contextlib.py", line 16, in __enter__
    return self.gen.next()
  File "/Users/shane/git/mongo-orchestration/venv-python2.6/lib/python2.6/site-packages/pymongo/mongo_client.py", line 859, in _socket_for_reads
    with self._get_socket(read_preference) as sock_info:
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/contextlib.py", line 16, in __enter__
    return self.gen.next()
  File "/Users/shane/git/mongo-orchestration/venv-python2.6/lib/python2.6/site-packages/pymongo/mongo_client.py", line 823, in _get_socket
    server = self._get_topology().select_server(selector)
  File "/Users/shane/git/mongo-orchestration/venv-python2.6/lib/python2.6/site-packages/pymongo/topology.py", line 214, in select_server
    address))
  File "/Users/shane/git/mongo-orchestration/venv-python2.6/lib/python2.6/site-packages/pymongo/topology.py", line 189, in select_servers
    self._error_message(selector))
ServerSelectionTimeoutError: connection closed
2017-07-26 10:40:02,114 [ERROR] mongo_orchestration.servers:346 - Could not start Server. Please find server log below.
=====================================================
2017-07-26 10:40:02,114 [ERROR] mongo_orchestration.servers:349 - 2017-07-26T10:37:00.953-0700 I CONTROL  [initandlisten] MongoDB starting : pid=98648 port=27017 dbpath=/var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-EUY6FY 64-bit host=Shanes-MacBook-Pro-2.local
2017-07-26T10:37:00.953-0700 I CONTROL  [initandlisten] db version v3.4.6
2017-07-26T10:37:00.953-0700 I CONTROL  [initandlisten] git version: c55eb86ef46ee7aede3b1e2a5d184a7df4bfb5b5
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.0.2l  25 May 2017
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten] allocator: system
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten] modules: none
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten] build environment:
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten]     distarch: x86_64
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten]     target_arch: x86_64
2017-07-26T10:37:00.954-0700 I CONTROL  [initandlisten] options: { config: "/var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-mYfNiC", net: { bindIp: "localhost,::1", ipv6: true, port: 27017, ssl: { CAFile: "/Users/shane/git/mongo-python-driver/test/certificates/ca.pem", PEMKeyFile: "/Users/shane/git/mongo-python-driver/test/certificates/server.pem", mode: "requireSSL", weakCertificateValidation: true } }, replication: { oplogSizeMB: 100 }, setParameter: { enableTestCommands: "1" }, storage: { dbPath: "/var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-EUY6FY" }, systemLog: { destination: "file", logAppend: true, path: "/var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-EUY6FY/mongod.log" } }
2017-07-26T10:37:00.954-0700 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=7680M,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
2017-07-26T10:37:01.315-0700 I CONTROL  [initandlisten] 
2017-07-26T10:37:01.315-0700 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2017-07-26T10:37:01.315-0700 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2017-07-26T10:37:01.315-0700 I CONTROL  [initandlisten] 
2017-07-26T10:37:01.412-0700 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-EUY6FY/diagnostic.data'
2017-07-26T10:37:01.577-0700 I INDEX    [initandlisten] build index on: admin.system.version properties: { v: 2, key: { version: 1 }, name: "incompatible_with_version_32", ns: "admin.system.version" }
2017-07-26T10:37:01.577-0700 I INDEX    [initandlisten] 	 building index using bulk method; build may temporarily use up to 500 megabytes of RAM
2017-07-26T10:37:01.588-0700 I INDEX    [initandlisten] build index done.  scanned 0 total records. 0 secs
2017-07-26T10:37:01.589-0700 I COMMAND  [initandlisten] setting featureCompatibilityVersion to 3.4
2017-07-26T10:37:01.589-0700 I NETWORK  [thread1] waiting for connections on port 27017 ssl
2017-07-26T10:37:01.721-0700 I NETWORK  [thread1] connection accepted from 127.0.0.1:60769 #1 (1 connection now open)
2017-07-26T10:37:01.721-0700 I -        [conn1] end connection 127.0.0.1:60769 (1 connection now open)
2017-07-26T10:37:01.724-0700 I NETWORK  [thread1] connection accepted from 127.0.0.1:60770 #2 (1 connection now open)
2017-07-26T10:37:01.752-0700 E NETWORK  [conn2] SSL peer certificate validation failed: unable to verify the first certificate
2017-07-26T10:37:01.753-0700 I -        [conn2] end connection 127.0.0.1:60770 (1 connection now open)
```

In this example we can diagnose that mongo-orchestration is trying to connect with an invalid certificate.