### PR TITLE
BUMP 0.6.10

### DIFF
--- a/mongo_orchestration/__init__.py
+++ b/mongo_orchestration/__init__.py
@@ -20,7 +20,7 @@ from mongo_orchestration.servers import Servers
 from mongo_orchestration.replica_sets import ReplicaSets
 from mongo_orchestration.sharded_clusters import ShardedClusters
 
-__version__ = '0.6.9'
+__version__ = '0.6.10'
 
 
 def set_releases(releases=None, default_release=None):

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class test(Command):
 
 setup(
     name='mongo-orchestration',
-    version='0.6.9',
+    version='0.6.10',
     author='MongoDB, Inc.',
     author_email='mongodb-user@googlegroups.com',
     description='Restful service for managing MongoDB servers',


### PR DESCRIPTION
This release fixes a number of issues with MongoDB 3.5 including:

1. Automatically enable compression with MongoDB >= 3.4.
1. Reduce maximum waiting time from 2.5 hours to 3 minutes when starting servers.
1. Do not run currentOp due to SERVER-30084.
1. Don't start mongod with --nohttpinterface. MongoDB 3.5.7+ no longer recognizes this option, SERVER-29000.