### PR TITLE
Use SCRAM-SHA-1 on MongoDB >= 3.7.2

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -105,7 +105,7 @@ class BaseModel(object):
             return [role['role'] for role in self._user_role_documents]
         return self._user_role_documents
 
-    def _add_users(self, db):
+    def _add_users(self, db, mongo_version):
         """Add given user, and extra x509 user if necessary."""
         if self.x509_extra_user:
             # Build dict of kwargs to pass to add_user.
@@ -125,6 +125,9 @@ class BaseModel(object):
         }
         if self.password:
             secondary_login['password'] = self.password
+        if mongo_version >= (3, 7, 2):
+            # Use SCRAM_SHA-1 so that pymongo < 3.7 can authenticate.
+            secondary_login['mechanisms'] = ['SCRAM-SHA-1']
         db.add_user(**secondary_login)
 
 

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -103,7 +103,14 @@ class ReplicaSet(BaseModel):
                     self.x509_extra_user = True
                     break
 
-            self._add_users(self.connection()[self.auth_source])
+            if config["members"]:
+                server_id = self._servers.host_to_server_id(
+                    self.member_id_to_host(0))
+                version = self._servers.version(server_id)
+            else:
+                version = (2, 4, 0)
+
+            self._add_users(self.connection()[self.auth_source], version)
         if self.restart_required:
             # Restart all the servers with auth flags and ssl.
             for idx, member in enumerate(members):

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -418,7 +418,8 @@ class Server(BaseModel):
             if len(auth_mechs) == 1 and auth_mechs[0] == 'MONGODB-X509':
                 self.x509_extra_user = True
 
-            super(Server, self)._add_users(self.connection[self.auth_source])
+            super(Server, self)._add_users(self.connection[self.auth_source],
+                                           self.version)
         except pymongo.errors.OperationFailure as e:
             logger.error("Error: {0}".format(e))
             # user added successfuly but OperationFailure exception raises
@@ -518,6 +519,13 @@ class Servers(Singleton, Container):
         result = self._storage[server_id].info()
         result['id'] = server_id
         return result
+
+    def version(self, server_id):
+        """return the binary version of the given server
+        Args:
+            server_id - server identity
+        """
+        return self._storage[server_id].version
 
     def hostname(self, server_id):
         return self._storage[server_id].hostname

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -137,6 +137,8 @@ class ShardedCluster(BaseModel):
             if self.password:
                 secondary_login['password'] = self.password
 
+            if mongos_version >= (3, 7, 2):
+                secondary_login['mechanisms'] = ['SCRAM-SHA-1']
             # Do the same for the shards.
             for shard_id, config in zip(self._shards, shard_configs):
                 shard = self._shards[shard_id]

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -127,7 +127,7 @@ class ShardedCluster(BaseModel):
             self._add_users(
                 self.connection().get_database(
                     self.auth_source, write_concern=write_concern.WriteConcern(
-                        fsync=True)))
+                        fsync=True)), mongos_version)
 
             # Secondary user given from request.
             secondary_login = {


### PR DESCRIPTION
This allows starting >=3.7.2 servers with auth.

Previously attempts would fail because pymongo does not support SCRAM-SHA-256:
```
RuntimeError: Error sending POST to cluster: Traceback (most recent call last):
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/__init__.py", line 66, in wrap
    return f(*arg, **kwd)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/replica_sets.py", line 80, in rs_create
    result = _rs_create(data)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/replica_sets.py", line 37, in _rs_create
    rs_id = ReplicaSets().create(params)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/replica_sets.py", line 630, in create
    repl = ReplicaSet(rs_params)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/replica_sets.py", line 106, in __init__
    self._add_users(self.connection()[self.auth_source])
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/common.py", line 128, in _add_users
    db.add_user(**secondary_login)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/database.py", line 953, in add_user
    (not uinfo["users"]), name, password, read_only, **kwargs)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/database.py", line 876, in _create_or_update_user
    self.command(command_name, name, **opts)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/database.py", line 516, in command
    codec_options, **kwargs)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/database.py", line 428, in _command
    parse_write_concern_error=parse_write_concern_error)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/pool.py", line 477, in command
    collation=collation)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/network.py", line 116, in command
    parse_write_concern_error=parse_write_concern_error)
  File "/Users/shane/venv-python3.6/lib/python3.6/site-packages/pymongo/helpers.py", line 210, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: Use of SCRAM-SHA-256 requires undigested passwords
```