### PR TITLE
Enable ipv6 on all servers if any have it enabled

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -201,6 +201,7 @@ def ipv6_enabled_sharded(params):
 
 def enable_ipv6_single(proc_params):
     proc_params.setdefault('ipv6', True)
+    proc_params.setdefault('bind_ip', '127.0.0.1,::1')
 
 
 def enable_ipv6_repl(params):

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -171,3 +171,43 @@ def orchestration_mkdtemp(prefix=None):
         kwargs['dir'] = TMP_DIR
 
     return tempfile.mkdtemp(**kwargs)
+
+
+def ipv6_enabled_single(params):
+    return params.get('ipv6')
+
+
+def ipv6_enabled_repl(params):
+    members = params.get('members', [])
+    return any(m.get('procParams', {}).get('ipv6') for m in members)
+
+
+def ipv6_enabled_repl_single(params):
+    if 'members' in params:
+        return ipv6_enabled_repl(params)
+    else:
+        # Standalone mongod or mongos
+        return ipv6_enabled_single(params)
+
+
+def ipv6_enabled_sharded(params):
+    configs = params.get('configsvrs', [])
+    routers = params.get('routers', [])
+    shards = params.get('shards', [])
+    return (any(ipv6_enabled_repl_single(p) for p in configs) or
+            any(ipv6_enabled_single(p) for p in routers) or
+            any(ipv6_enabled_repl_single(p) for p in shards))
+
+
+def enable_ipv6_single(params):
+    params.setdefault('ipv6', True)
+
+
+def enable_ipv6_repl(params):
+    if 'members' in params:
+        members = params['members']
+        for m in members:
+            m.setdefault('procParams', {}).setdefault('ipv6', True)
+    else:
+        # Standalone mongod or mongos
+        params.setdefault('ipv6', True)

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -199,15 +199,15 @@ def ipv6_enabled_sharded(params):
             any(ipv6_enabled_repl_single(p) for p in shards))
 
 
-def enable_ipv6_single(params):
-    params.setdefault('ipv6', True)
+def enable_ipv6_single(proc_params):
+    proc_params.setdefault('ipv6', True)
 
 
 def enable_ipv6_repl(params):
     if 'members' in params:
         members = params['members']
         for m in members:
-            m.setdefault('procParams', {}).setdefault('ipv6', True)
+            enable_ipv6_single(m.setdefault('procParams', {}))
     else:
         # Standalone mongod or mongos
-        params.setdefault('ipv6', True)
+        enable_ipv6_single(params.setdefault('procParams', {}))


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5aafe59ee3c33148ba69f656

This is a working around for [SERVER-33790](https://jira.mongodb.org/browse/SERVER-33790).