### PR TITLE
Fix TypeError when logging auth failure

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -429,8 +429,8 @@ class ReplicaSet(BaseModel):
                         self.login, self.password)
             except Exception:
                 logger.exception(
-                    "Could not authenticate to %s as %s/%s"
-                    % (','.join(client.nodes), self.login, self.password))
+                    "Could not authenticate to %r as %s/%s"
+                    % (client, self.login, self.password))
                 raise
 
     def connection(self, hostname=None, read_preference=pymongo.ReadPreference.PRIMARY, timeout=300):


### PR DESCRIPTION
Fixes this error:
```
  File "c:\data\mci\d0496e0a3446f227ed1275fb7ba479e4\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\replica_sets.py", line 433, in _authenticate_client
    % (','.join(client.nodes), self.login, self.password))
TypeError: sequence item 0: expected string, tuple found
2018-04-16 22:42:16,683 [DEBUG] mongo_orchestration.apps:55 - send_result(500)
```

The log now looks like:
```
2018-04-17 09:53:24,066 [ERROR] mongo_orchestration.replica_sets:433 - Could not authenticate to MongoReplicaSetClient(host=['localhost:27017'], document_class=dict, tz_aware=False, connect=True, replicaset='b1d2bf32-c4c6-4e83-8d5f-b489477b455b', read_preference=Primary(), sockettimeoutms=20000, w=1, fsync=True) as user/password
```