### PR TITLE
Stop servers with the shutdown command before killing forcefully

### DIFF
--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -160,18 +160,23 @@ def wait_for(port_num, timeout):
 
 def repair_mongo(name, dbpath):
     """repair mongodb after usafe shutdown"""
-    cmd = [name, "--dbpath", dbpath, "--repair"]
-    proc = subprocess.Popen(cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
-    timeout = 30
+    log_file = os.path.join(dbpath, 'mongod.log')
+    cmd = [name, "--dbpath", dbpath, "--logPath", log_file, "--logappend",
+           "--repair"]
+    proc = subprocess.Popen(cmd)
+    timeout = 45
     t_start = time.time()
     while time.time() - t_start < timeout:
-        proc.stdout.flush()
-        line = str(proc.stdout.readline())
-        if "dbexit: really exiting now" in line:
+        return_code = proc.poll()
+        if return_code is not None:
+            if return_code:
+                raise Exception("mongod --repair failed with exit code %s, "
+                                "check log file: %s" % (return_code, log_file))
+            # Success when poll() returns 0
             return
-    return
+        time.sleep(1)
+    raise Exception("mongod --repair failed to exit after %s seconds, "
+                    "check log file: %s" % (timeout, log_file))
 
 
 def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):

--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -169,7 +169,6 @@ def repair_mongo(name, dbpath):
     timeout = 45
     t_start = time.time()
     while time.time() - t_start < timeout:
-        # proc.stdout.flush()
         line = str(proc.stdout.readline())
         logger.info("repair output: %s" % (line,))
         return_code = proc.poll()

--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -163,10 +163,15 @@ def repair_mongo(name, dbpath):
     log_file = os.path.join(dbpath, 'mongod.log')
     cmd = [name, "--dbpath", dbpath, "--logPath", log_file, "--logappend",
            "--repair"]
-    proc = subprocess.Popen(cmd)
+    proc = subprocess.Popen(
+        cmd, universal_newlines=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     timeout = 45
     t_start = time.time()
     while time.time() - t_start < timeout:
+        # proc.stdout.flush()
+        line = str(proc.stdout.readline())
+        logger.info("repair output: %s" % (line,))
         return_code = proc.poll()
         if return_code is not None:
             if return_code:

--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -161,7 +161,7 @@ def wait_for(port_num, timeout):
 def repair_mongo(name, dbpath):
     """repair mongodb after usafe shutdown"""
     log_file = os.path.join(dbpath, 'mongod.log')
-    cmd = [name, "--dbpath", dbpath, "--logPath", log_file, "--logappend",
+    cmd = [name, "--dbpath", dbpath, "--logpath", log_file, "--logappend",
            "--repair"]
     proc = subprocess.Popen(
         cmd, universal_newlines=True,

--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -179,6 +179,7 @@ def repair_mongo(name, dbpath):
             # Success when poll() returns 0
             return
         time.sleep(1)
+    proc.terminate()
     raise Exception("mongod --repair failed to exit after %s seconds, "
                     "check log file: %s" % (timeout, log_file))
 

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -48,7 +48,7 @@ class Server(BaseModel):
     enable_majority_read_concern = False
 
     # default params for all mongo instances
-    mongod_default = {"oplogSize": 100}
+    mongod_default = {"oplogSize": 100, "logappend": True}
 
     # regular expression matching MongoDB versions
     version_patt = re.compile(
@@ -325,8 +325,10 @@ class Server(BaseModel):
         if self.is_alive:
             return True
         try:
-            if self.cfg.get('dbpath', None) and self._is_locked:
+            dbpath = self.cfg.get('dbpath', None)
+            if dbpath and self._is_locked:
                 # repair if needed
+                logger.info("Performing repair on locked dbpath={dbpath}".format(dbpath=dbpath))
                 process.repair_mongo(self.name, self.cfg['dbpath'])
 
             self.proc, self.hostname = process.mprocess(

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -326,10 +326,10 @@ class Server(BaseModel):
         if self.is_alive:
             return True
         try:
-            dbpath = self.cfg.get('dbpath', None)
+            dbpath = self.cfg.get('dbpath')
             if dbpath and self._is_locked:
                 # repair if needed
-                logger.info("Performing repair on locked dbpath={dbpath}".format(dbpath=dbpath))
+                logger.info("Performing repair on locked dbpath %s", dbpath)
                 process.repair_mongo(self.name, self.cfg['dbpath'])
 
             self.proc, self.hostname = process.mprocess(


### PR DESCRIPTION
Changes:
- Stop servers with the shutdown command before killing forcefully
- Default logappend=True
- Add logging when `mongod --repair` is run.

Patch: https://evergreen.mongodb.com/version/5ad8e754c9ec442ea9918c46