### PR TITLE
Allow running in background from git checkout.

### DIFF
--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -171,6 +171,7 @@ def main():
     if args.command == 'stop':
         daemon.stop()
     if args.command == 'start' and not args.no_fork:
+        get_app()
         print('Preparing to start mongo-orchestration daemon')
         pid = daemon.start()
         print('Daemon process started with pid: %d' % pid)


### PR DESCRIPTION
Running from a git checkout (with local paths) means Python
modules have local paths to them, which doesn't work too well
with daemonization as part of daemonization chdirs to /.

To fix, preload the application prior to daemonization.