### PR TITLE
Increase default mongo logging verbosity

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -49,7 +49,7 @@ class Server(BaseModel):
     enable_majority_read_concern = False
 
     # default params for all mongo instances
-    mongod_default = {"oplogSize": 100, "logappend": True}
+    mongod_default = {"oplogSize": 100, "logappend": True, "verbose": "v"}
 
     # regular expression matching MongoDB versions
     version_patt = re.compile(


### PR DESCRIPTION
Resolves #254. 

Testing this change on 2.4-4.2 latest via drivers-evergreen-tools here: https://evergreen.mongodb.com/version/5bad09382fbabe5a990120e5