### PR TITLE
Avoid recommending use of direct invocation of setup.py.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ manually:
 
     git clone https://github.com/10gen/mongo-orchestration.git
     cd mongo-orchestration
-    python setup.py install
+    pip install .
 
 Cloning the `repository <https://github.com/10gen/mongo-orchestration>`__ this way will also give you access to the tests for Mongo Orchestration as well as the ``mo`` script. Note that you may
 have to run the above commands with ``sudo``, depending on where you're


### PR DESCRIPTION
As a member of PyPA, I'm confident that the use of direct invocation of `setup.py install` is discouraged. I'd like to update the README docs for this project to reflect a preferred usage.