### PR TITLE
Rely on portend to await the port.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,8 @@ setup(
     url='https://github.com/10gen/mongo-orchestration',
     install_requires=['pymongo>=3.0.2,<3.6.0',
                       'bottle>=0.12.7',
-                      'CherryPy>=3.5.0,<7.1'] + extra_deps,
+                      'CherryPy>=3.5.0,<7.1',
+                      'portend'] + extra_deps,
     extras_require={
         ':python_version=="2.6"': py26_requires
     },


### PR DESCRIPTION
This PR represents an alternate approach to #258, relying on [portend](https://pypi.org/project/portend), itself derived from the CherryPy project, to await the connection.