### PR TITLE
Capture server startup errors in log files stdout/stderr to the server's log file

### DIFF
--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -156,8 +156,6 @@ def await_connection(host, port):
 def main():
     args = read_env()
     Server.enable_majority_read_concern = args.enable_majority_read_concern
-    # Silence STDOUT from mongo processes if MO is running as a deamon.
-    Server.silence_stdout = not args.no_fork
     # Log both to STDOUT and the log file.
     logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE,
                         format=LOGGING_FORMAT)

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -43,8 +43,6 @@ logger = logging.getLogger(__name__)
 class Server(BaseModel):
     """Class Server represents behaviour of  mongo instances """
 
-    # redirect stdout to /dev/null?
-    silence_stdout = True
     # Try to enable majority read concern?
     enable_majority_read_concern = False
 
@@ -59,7 +57,7 @@ class Server(BaseModel):
 
     def __init_db(self, dbpath):
         if not dbpath:
-            dbpath = orchestration_mkdtemp(prefix="mongo-")
+            dbpath = orchestration_mkdtemp(prefix="mongod-")
         if not os.path.exists(dbpath):
             os.makedirs(dbpath)
         return dbpath
@@ -69,6 +67,7 @@ class Server(BaseModel):
         log_dir = os.path.dirname(log_path)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
+        self._log_path = log_path
 
     def __init_config_params(self, config):
         """Conditionally enable options in the Server's config file."""
@@ -141,7 +140,7 @@ class Server(BaseModel):
 
         log_path = cfg.setdefault(
             'logpath',
-            os.path.join(orchestration_mkdtemp(prefix='mongo-'), 'mongos.log'))
+            os.path.join(orchestration_mkdtemp(prefix='mongos-'), 'mongos.log'))
         self.__init_logpath(log_path)
 
         # use keyFile
@@ -179,6 +178,7 @@ class Server(BaseModel):
         self.ssl_params = sslParams
         self.restart_required = self.login or self.auth_key
         self.__version = None
+        self._log_path = None
 
         if self.ssl_params:
             self.kwargs.update(DEFAULT_SSL_OPTIONS)
@@ -340,8 +340,8 @@ class Server(BaseModel):
                 process.repair_mongo(self.name, self.cfg['dbpath'])
 
             self.proc, self.hostname = process.mprocess(
-                self.name, self.config_path, self.cfg.get('port', None),
-                timeout, self.silence_stdout)
+                self.name, self.config_path, self._log_path,
+                self.cfg.get('port', None), timeout)
             self.pid = self.proc.pid
             logger.debug("pid={pid}, hostname={hostname}".format(pid=self.pid, hostname=self.hostname))
             self.host = self.hostname.split(':')[0]


### PR DESCRIPTION
The nice thing about this change is that we now capture server start-up errors. For example, errors like `[main] Failed global initialization: BadValue: Unknown --setParameter 'failpoint.disableStapling'` will now be shown in the logs:
```
2020-02-26 10:30:57,888 [DEBUG] mongo_orchestration.server:184 - Starting mongo-orchestration in the foreground
2020-02-26 10:30:57,889 [DEBUG] mongo_orchestration.server:131 - Starting HTTP server on host: localhost; port: 8889
2020-02-26 10:31:06,893 [DEBUG] mongo_orchestration.apps:64 - rs_create((), {})
2020-02-26 10:31:06,893 [DEBUG] mongo_orchestration.apps.replica_sets:77 - rs_create()
2020-02-26 10:31:06,894 [DEBUG] mongo_orchestration.servers:168 - Server.__init__(mongod, {u'bind_ip': u'127.0.0.1,::1', 'replSet': '35610070-c498-4290-be0b-805ea12a64f1', u'ipv6': True, u'setParameter': {u'enableTestCommands': 1, u'failpoint.disableStapling': u'{"mode":"alwaysOn"}'}, u'logappend': True, u'port': 27017}, {}, None, None, None)
2020-02-26 10:31:06,894 [DEBUG] mongo_orchestration.servers:68 - Creating log file for mongod: /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongod-2VkU2E/mongod.log
2020-02-26 10:31:06,894 [DEBUG] mongo_orchestration.servers:229 - ('mongod', '--version')
2020-02-26 10:31:06,917 [DEBUG] mongo_orchestration.process:220 - mprocess(name='mongod', config_path='/var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongo-nbhL8F', port=27017, timeout=300)
2020-02-26 10:31:06,918 [DEBUG] mongo_orchestration.process:232 - execute process: mongod --config /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongo-nbhL8F --port 27017
2020-02-26 10:31:06,923 [DEBUG] mongo_orchestration.process:166 - wait for 27017
2020-02-26 10:31:06,948 [DEBUG] mongo_orchestration.process:171 - process is not alive
2020-02-26 10:31:06,948 [ERROR] mongo_orchestration.servers:370 - Could not start Server. Please find server log below.
=====================================================
2020-02-26 10:31:06,948 [ERROR] mongo_orchestration.servers:373 - 2020-02-26T10:31:06.946-0800 F  CONTROL  [main] Failed global initialization: BadValue: Unknown --setParameter 'failpoint.disableStapling'

2020-02-26 10:31:06,949 [ERROR] mongo_orchestration.apps:68 - <function rs_create at 0x1026e6ed8>
Traceback (most recent call last):
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/__init__.py", line 66, in wrap
    return f(*arg, **kwd)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/replica_sets.py", line 80, in rs_create
    result = _rs_create(data)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/apps/replica_sets.py", line 37, in _rs_create
    rs_id = ReplicaSets().create(params)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/replica_sets.py", line 643, in create
    repl = ReplicaSet(rs_params)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/replica_sets.py", line 74, in __init__
    for index, member in enumerate(members)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/replica_sets.py", line 317, in member_create
    server_id=server_id
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 520, in create
    server.start(timeout)
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/servers.py", line 382, in start
    LOG_FILE + ' for more details.')
  File "<string>", line 2, in reraise
TimeoutError: Could not start Server. Please check server log located in /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongod-2VkU2E/mongod.log or the mongo-orchestration log in /Users/shane/mongo-orchestration/server.log for more details.
2020-02-26 10:31:06,949 [DEBUG] mongo_orchestration.apps:55 - send_result(500)
```

Two changes:
- Redirect the mongo process' stdout/stderr to the server's log file.
- Check that the server is still alive when a waiting for a server to start accepting connections. This exits early when the server dies soon after it is started.

CC: @vincentkam