### PR TITLE
Redirect mongo startup errors (written to stdout/stderr) to the MO log

### DIFF
--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from bottle import request
 
-from mongo_orchestration.common import DEFAULT_BIND
+from mongo_orchestration.common import DEFAULT_BIND, LOG_FILE
 from mongo_orchestration.compat import reraise, PY3
 from mongo_orchestration.errors import TimeoutError, RequestError
 from mongo_orchestration.singleton import Singleton
@@ -135,9 +135,30 @@ class PortPool(Singleton):
         self.__init_range(min_port, max_port, port_sequence)
 
 
-def wait_for(port_num, timeout):
+def connect_port(port):
     """waits while process starts.
     Args:
+        proc        - Popen object
+        port_num    - port number
+        timeout     - specify how long, in seconds, a command can take before times out.
+    return True if process started, return False if not
+    """
+    s = None
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((_host(), port))
+        s.close()
+        return True
+    except (IOError, socket.error):
+        if s:
+            s.close()
+        return False
+
+
+def wait_for(proc, port_num, timeout):
+    """waits while process starts.
+    Args:
+        proc        - Popen object
         port_num    - port number
         timeout     - specify how long, in seconds, a command can take before times out.
     return True if process started, return False if not
@@ -146,15 +167,11 @@ def wait_for(port_num, timeout):
     t_start = time.time()
     sleeps = 0.1
     while time.time() - t_start < timeout:
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                s.connect((_host(), port_num))
-                return True
-            except (IOError, socket.error):
-                time.sleep(sleeps)
-        finally:
-            s.close()
+        if proc.poll() is not None:
+            logger.debug("process is not alive")
+            raise OSError("Process started, but died immediately")
+        if connect_port(port_num):
+            return True
     return False
 
 
@@ -184,7 +201,7 @@ def repair_mongo(name, dbpath):
                     "check log file: %s" % (timeout, log_file))
 
 
-def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):
+def mprocess(name, config_path, port=None, timeout=180):
     """start 'name' process with params from config_path.
     Args:
         name - process name or path
@@ -192,7 +209,6 @@ def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):
         port - process's port
         timeout - specify how long, in seconds, a command can take before times out.
                   if timeout <=0 - doesn't wait for complete start process
-        silence_stdout - if True (default), redirect stdout to /dev/null
     return tuple (Popen object, host) if process started, return (None, None) if not
     """
 
@@ -211,29 +227,35 @@ def mprocess(name, config_path, port=None, timeout=180, silence_stdout=True):
     host = "{host}:{port}".format(host=_host(), port=port)
     try:
         logger.debug("execute process: %s", ' '.join(cmd))
-        proc = subprocess.Popen(
-            cmd,
-            stdout=DEVNULL if silence_stdout else None,
-            stderr=subprocess.STDOUT)
+        # Redirect server startup errors (written to stdout/stderr) to our log
+        with open(LOG_FILE, 'a+') as outfile:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=outfile,
+                stderr=subprocess.STDOUT)
 
-        if proc.poll() is not None:
-            logger.debug("process is not alive")
-            raise OSError("Process started, but died immediately.")
+            if proc.poll() is not None:
+                logger.debug("process is not alive")
+                raise OSError("Process started, but died immediately.")
     except (OSError, TypeError) as err:
         message = "exception while executing process: {err}".format(err=err)
         logger.debug(message)
         raise OSError(message)
-    if timeout > 0 and wait_for(port, timeout):
-        logger.debug("process '{name}' has started: pid={proc.pid}, host={host}".format(**locals()))
-        return (proc, host)
-    elif timeout > 0:
-        logger.debug("hasn't connected to pid={proc.pid} with host={host} during timeout {timeout} ".format(**locals()))
-        logger.debug("terminate process with pid={proc.pid}".format(**locals()))
-        kill_mprocess(proc)
-        proc_alive(proc) and time.sleep(3)  # wait while process stoped
-        message = ("Could not connect to process during "
-                   "{timeout} seconds".format(timeout=timeout))
-        raise TimeoutError(message, errno.ETIMEDOUT)
+    if timeout > 0:
+        if wait_for(proc, port, timeout):
+            logger.debug("process '{name}' has started: pid={proc.pid},"
+                         " host={host}".format(**locals()))
+            return (proc, host)
+        else:
+            logger.debug("hasn't connected to pid={proc.pid} with host={host}"
+                         " during timeout {timeout} ".format(**locals()))
+            logger.debug("terminate process with"
+                         " pid={proc.pid}".format(**locals()))
+            kill_mprocess(proc)
+            proc_alive(proc) and time.sleep(3)  # wait while process stoped
+            message = ("Could not connect to process during "
+                       "{timeout} seconds".format(timeout=timeout))
+            raise TimeoutError(message, errno.ETIMEDOUT)
     return (proc, host)
 
 

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -156,8 +156,6 @@ def await_connection(host, port):
 def main():
     args = read_env()
     Server.enable_majority_read_concern = args.enable_majority_read_concern
-    # Silence STDOUT from mongo processes if MO is running as a deamon.
-    Server.silence_stdout = not args.no_fork
     # Log both to STDOUT and the log file.
     logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE,
                         format=LOGGING_FORMAT)

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -43,8 +43,6 @@ logger = logging.getLogger(__name__)
 class Server(BaseModel):
     """Class Server represents behaviour of  mongo instances """
 
-    # redirect stdout to /dev/null?
-    silence_stdout = True
     # Try to enable majority read concern?
     enable_majority_read_concern = False
 
@@ -59,7 +57,7 @@ class Server(BaseModel):
 
     def __init_db(self, dbpath):
         if not dbpath:
-            dbpath = orchestration_mkdtemp(prefix="mongo-")
+            dbpath = orchestration_mkdtemp(prefix="mongod-")
         if not os.path.exists(dbpath):
             os.makedirs(dbpath)
         return dbpath
@@ -141,7 +139,7 @@ class Server(BaseModel):
 
         log_path = cfg.setdefault(
             'logpath',
-            os.path.join(orchestration_mkdtemp(prefix='mongo-'), 'mongos.log'))
+            os.path.join(orchestration_mkdtemp(prefix='mongos-'), 'mongos.log'))
         self.__init_logpath(log_path)
 
         # use keyFile
@@ -341,7 +339,7 @@ class Server(BaseModel):
 
             self.proc, self.hostname = process.mprocess(
                 self.name, self.config_path, self.cfg.get('port', None),
-                timeout, self.silence_stdout)
+                timeout)
             self.pid = self.proc.pid
             logger.debug("pid={pid}, hostname={hostname}".format(pid=self.pid, hostname=self.hostname))
             self.host = self.hostname.split(':')[0]


### PR DESCRIPTION
Check that the server is still alive when a waiting for a server to start
accepting connections.

This change completes #279 which I had to revert. Instead of redirecting the mongod output to the mongod.log we redirect it to the MO log file (`server.log`). This works on Windows and other platforms (note the `CONTROL  [main] Failed global initialization: BadValue: Unknown --setParameter 'failpoint.disableStapling'` line which was previously surpressed):
```
$ cat ~/mongo-orchestration/server.log
2020-02-26 15:20:22,339 [DEBUG] mongo_orchestration.server:182 - Starting mongo-orchestration in the foreground
2020-02-26 15:20:22,339 [DEBUG] mongo_orchestration.server:131 - Starting HTTP server on host: localhost; port: 8889
2020-02-26 15:20:25,128 [DEBUG] mongo_orchestration.apps:64 - rs_create((), {})
2020-02-26 15:20:25,128 [DEBUG] mongo_orchestration.apps.replica_sets:77 - rs_create()
2020-02-26 15:20:25,128 [DEBUG] mongo_orchestration.servers:166 - Server.__init__(mongod, {u'bind_ip': u'127.0.0.1,::1', 'replSet': 'a828b22d-cad8-4be9-b4f9-d9f403c544e3', u'ipv6': True, u'setParameter': {u'enableTestCommands': 1, u'failpoint.disableStapling': u'{"mode":"alwaysOn"}'}, u'logappend': True, u'port': 27017}, {}, None, None, None)
2020-02-26 15:20:25,128 [DEBUG] mongo_orchestration.servers:66 - Creating log file for mongod: /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongod-PDYLaf/mongod.log
2020-02-26 15:20:25,128 [DEBUG] mongo_orchestration.servers:227 - ('mongod', '--version')
2020-02-26 15:20:25,153 [DEBUG] mongo_orchestration.process:218 - mprocess(name='mongod', config_path='/var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongo-mujz1n', port=27017, timeout=300)
2020-02-26 15:20:25,153 [DEBUG] mongo_orchestration.process:230 - execute process: mongod --config /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongo-mujz1n --port 27017
2020-02-26 15:20:25,158 [DEBUG] mongo_orchestration.process:166 - wait for 27017
2020-02-26T15:20:25.182-0800 F  CONTROL  [main] Failed global initialization: BadValue: Unknown --setParameter 'failpoint.disableStapling'
2020-02-26 15:20:25,184 [DEBUG] mongo_orchestration.process:171 - process is not alive
2020-02-26 15:20:25,184 [ERROR] mongo_orchestration.servers:368 - Could not start Server. Please find server log below.
=====================================================
```

This time I've tested that the change works on Windows/Linux: https://evergreen.mongodb.com/version/5e56eeb47742ae683a2c03d9

CC: @vincentkam