### PR TITLE
Create admin user with both SCRAM-SHA-256 and SCRAM-SHA-1

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -107,28 +107,23 @@ class BaseModel(object):
 
     def _add_users(self, db, mongo_version):
         """Add given user, and extra x509 user if necessary."""
+        roles = self._user_roles(db.client)
         if self.x509_extra_user:
-            # Build dict of kwargs to pass to add_user.
-            auth_dict = {
-                'name': DEFAULT_SUBJECT,
-                'roles': self._user_roles(db.client)
-            }
-            db.add_user(**auth_dict)
+            db.add_user(DEFAULT_SUBJECT, roles=roles)
             # Fix kwargs to MongoClient.
             self.kwargs['ssl_certfile'] = DEFAULT_CLIENT_CERT
 
         # Add secondary user given from request.
+        create_user(db, mongo_version, self.login, self.password, roles)
 
-        secondary_login = {
-            'name': self.login,
-            'roles': self._user_roles(db.client)
-        }
-        if self.password:
-            secondary_login['password'] = self.password
-        if mongo_version >= (3, 7, 2):
-            # Use SCRAM_SHA-1 so that pymongo < 3.7 can authenticate.
-            secondary_login['mechanisms'] = ['SCRAM-SHA-1']
-        db.add_user(**secondary_login)
+
+def create_user(db, mongo_version, user, password, roles):
+    if mongo_version >= (3, 7, 2):
+        # Use SCRAM_SHA-1 so that pymongo < 3.7 can authenticate.
+        db.command('createUser', user, pwd=password, roles=roles,
+                   mechanisms=['SCRAM-SHA-1', 'SCRAM-SHA-256'])
+    else:
+        db.add_user(user, password=password, roles=roles)
 
 
 def connected(client):

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -119,9 +119,10 @@ class BaseModel(object):
 
 def create_user(db, mongo_version, user, password, roles):
     if mongo_version >= (3, 7, 2):
-        # Use SCRAM_SHA-1 so that pymongo < 3.7 can authenticate.
-        db.command('createUser', user, pwd=password, roles=roles,
-                   mechanisms=['SCRAM-SHA-1', 'SCRAM-SHA-256'])
+        # Call createUser directly so that the server creates the user with
+        # both SCRAM-SHA-1 and SCRAM-SHA-256 credentials. This ensures that
+        # pymongo < 3.7 (which only supports SCRAM-SHA-1) can authenticate.
+        db.command('createUser', user, pwd=password, roles=roles)
     else:
         db.add_user(user, password=password, roles=roles)
 


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5e7a92621e2d1721e6d4e979

This change adds SCRAM-SHA-256 to the admin user created by MO at startup. Previously, this user was restricted to SCRAM-SHA-1. Now a driver can authenticate with either SCRAM-SHA-256 or SCRAM-SHA-1.

This was changed so that drivers can take advantage of speculative SCRAM-SHA-256 authentication when connecting with this admin user.

This change also resolves #260.