### PR TITLE
Ensure createUser succeeds on all replica set members

### DIFF
--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -122,7 +122,8 @@ def create_user(db, mongo_version, user, password, roles):
         # Call createUser directly so that the server creates the user with
         # both SCRAM-SHA-1 and SCRAM-SHA-256 credentials. This ensures that
         # pymongo < 3.7 (which only supports SCRAM-SHA-1) can authenticate.
-        db.command('createUser', user, pwd=password, roles=roles)
+        db.command('createUser', user, pwd=password, roles=roles,
+                   writeConcern=db.write_concern.document)
     else:
         db.add_user(user, password=password, roles=roles)
 


### PR DESCRIPTION
Fixes this error:
```
 [2020/03/26 19:02:59.279] + curl --silent --show-error --data @/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/configs/replica_sets/auth-ssl.json http://localhost:8889/v1/replica_sets --max-time 600 --fail -o tmp.json
 [2020/03/26 19:03:17.138] curl: (22) The requested URL returned error: 500 Internal Server Error
 [2020/03/26 19:03:17.138] + echo Failed to start cluster, see /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/out.log:
 [2020/03/26 19:03:17.138] + cat /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/out.log
 [2020/03/26 19:03:17.138] Failed to start cluster, see /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/out.log:
 [2020/03/26 19:03:17.138] Preparing to start mongo-orchestration daemon
 [2020/03/26 19:03:17.138] Preparing to start mongo-orchestration daemon
 [2020/03/26 19:03:17.138] Preparing to start mongo-orchestration daemon
 [2020/03/26 19:03:17.138] Daemon process started with pid: 21446
 [2020/03/26 19:03:17.138] + echo Failed to start cluster, see /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/server.log:
 [2020/03/26 19:03:17.138] + cat /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/server.log
 [2020/03/26 19:03:17.138] Failed to start cluster, see /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/server.log:
 [2020/03/26 19:03:17.139] From shell Thu Mar 26 19:02:41 UTC 2020
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,434 [INFO] mongo_orchestration.daemon:132 - Starting daemon
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,434 [INFO] mongo_orchestration.daemon:78 - daemonize_posix
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,434 [DEBUG] mongo_orchestration.daemon:82 - forked first child, pid = 21446
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,435 [DEBUG] mongo_orchestration.daemon:84 - in child after first fork, pid = 0
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,435 [DEBUG] mongo_orchestration.daemon:100 - forked second child, pid = 21447, exiting
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,440 [INFO] mongo_orchestration.daemon:108 - daemonized, pid = 0
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:49,441 [DEBUG] mongo_orchestration.server:131 - Starting HTTP server on host: 127.0.0.1; port: 8889
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:54,276 [DEBUG] mongo_orchestration.apps:64 - base_uri((), {})
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:54,276 [DEBUG] mongo_orchestration.apps.servers:61 - base_uri()
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:54,277 [DEBUG] mongo_orchestration.apps:55 - send_result(200)
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,287 [DEBUG] mongo_orchestration.apps:64 - rs_create((), {})
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,287 [DEBUG] mongo_orchestration.apps.replica_sets:77 - rs_create()
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,288 [DEBUG] mongo_orchestration.servers:165 - Server.__init__(/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod, {u'oplogSize': 500, u'bind_ip': u'127.0.0.1,::1', 'replSet': u'repl0', u'ipv6': True, u'journal': True, u'port': 27017}, {u'sslOnNormalPorts': True, u'sslWeakCertificateValidation': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem'}, None, None, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,289 [DEBUG] mongo_orchestration.servers:66 - Creating log file for /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk/mongod.log
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,289 [DEBUG] mongo_orchestration.servers:225 - ('/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', '--version')
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,307 [DEBUG] mongo_orchestration.process:217 - mprocess(name='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', config_path='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-sMwU6F', port=27017, timeout=300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,308 [DEBUG] mongo_orchestration.process:229 - execute process: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod --config /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-sMwU6F --port 27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:02:59,311 [DEBUG] mongo_orchestration.process:166 - wait for 27017
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:02:59.333Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslOnNormalPorts","option_singleName":"tlsOnNormalPorts"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:02:59.333Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslPEMKeyFile","option_singleName":"tlsCertificateKeyFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:02:59.333Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslCAFile","option_singleName":"tlsCAFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:02:59.333Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslWeakCertificateValidation","option_singleName":"tlsAllowConnectionsWithoutCertificates"}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,020 [DEBUG] mongo_orchestration.process:247 - process '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod' has started: pid=21464, host=localhost:27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,020 [DEBUG] mongo_orchestration.servers:344 - pid=21464, hostname=localhost:27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,035 [DEBUG] mongo_orchestration.servers:165 - Server.__init__(/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod, {u'oplogSize': 500, u'bind_ip': u'127.0.0.1,::1', 'replSet': u'repl0', u'ipv6': True, u'journal': True, u'port': 27018}, {u'sslOnNormalPorts': True, u'sslWeakCertificateValidation': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem'}, None, None, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,035 [DEBUG] mongo_orchestration.servers:66 - Creating log file for /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw/mongod.log
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,035 [DEBUG] mongo_orchestration.servers:225 - ('/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', '--version')
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,054 [DEBUG] mongo_orchestration.process:217 - mprocess(name='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', config_path='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-uxWLDA', port=27018, timeout=300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,055 [DEBUG] mongo_orchestration.process:229 - execute process: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod --config /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-uxWLDA --port 27018
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:01,058 [DEBUG] mongo_orchestration.process:166 - wait for 27018
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:01.075Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslOnNormalPorts","option_singleName":"tlsOnNormalPorts"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:01.075Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslPEMKeyFile","option_singleName":"tlsCertificateKeyFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:01.075Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslCAFile","option_singleName":"tlsCAFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:01.075Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslWeakCertificateValidation","option_singleName":"tlsAllowConnectionsWithoutCertificates"}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,060 [DEBUG] mongo_orchestration.process:247 - process '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod' has started: pid=21510, host=localhost:27018
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,060 [DEBUG] mongo_orchestration.servers:344 - pid=21510, hostname=localhost:27018
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,081 [DEBUG] mongo_orchestration.servers:165 - Server.__init__(/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod, {u'journal': True, u'bind_ip': u'127.0.0.1,::1', u'port': 27019, 'replSet': u'repl0', u'ipv6': True}, {u'sslOnNormalPorts': True, u'sslWeakCertificateValidation': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem'}, None, None, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,081 [DEBUG] mongo_orchestration.servers:66 - Creating log file for /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ/mongod.log
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,081 [DEBUG] mongo_orchestration.servers:225 - ('/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', '--version')
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,109 [DEBUG] mongo_orchestration.process:217 - mprocess(name='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', config_path='/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-aofXMz', port=27019, timeout=300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,109 [DEBUG] mongo_orchestration.process:229 - execute process: /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod --config /data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-aofXMz --port 27019
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:02,115 [DEBUG] mongo_orchestration.process:166 - wait for 27019
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:02.135Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslOnNormalPorts","option_singleName":"tlsOnNormalPorts"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:02.135Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslPEMKeyFile","option_singleName":"tlsCertificateKeyFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:02.135Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslCAFile","option_singleName":"tlsCAFile"}}
 [2020/03/26 19:03:17.139] {"t":{"$date":"2020-03-26T19:03:02.136Z"},"s":"W", "c":"CONTROL", "id":23321,"ctx":"main","msg":"Option: {singleName} is deprecated. Please use {option_singleName} instead.","attr":{"singleName":"sslWeakCertificateValidation","option_singleName":"tlsAllowConnectionsWithoutCertificates"}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,252 [DEBUG] mongo_orchestration.process:247 - process '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod' has started: pid=21556, host=localhost:27019
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,252 [DEBUG] mongo_orchestration.servers:344 - pid=21556, hostname=localhost:27019
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,272 [DEBUG] mongo_orchestration.replica_sets:86 - replica config: {'_id': u'repl0', 'members': [{'host': 'localhost:27017', '_id': 0, u'tags': {u'ordinal': u'one', u'dc': u'ny'}}, {'host': 'localhost:27018', '_id': 1, u'tags': {u'ordinal': u'two', u'dc': u'pa'}}, {'host': 'localhost:27019', '_id': 2}]}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,273 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27017, Primary(), 5)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,273 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,291 [DEBUG] mongo_orchestration.replica_sets:534 - server_info: {u'info': u'Does not have a valid replica set config', u'ismaster': False, u'maxWriteBatchSize': 100000, u'ok': 1.0, u'maxWireVersion': 9, u'logicalSessionTimeoutMinutes': 30, u'readOnly': False, u'topologyVersion': {u'processId': ObjectId('5e7cfc637437028946f5530b'), u'counter': 0L}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 3, 290000), u'connectionId': 5, u'isreplicaset': True, u'minWireVersion': 0, u'maxBsonObjectSize': 16777216, u'$clusterTime': {u'clusterTime': Timestamp(0, 0), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'operationTime': Timestamp(0, 0), u'maxMessageSizeBytes': 48000000, u'secondary': False}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,291 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27018, Primary(), 5)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,291 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27018
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,311 [DEBUG] mongo_orchestration.replica_sets:534 - server_info: {u'info': u'Does not have a valid replica set config', u'ismaster': False, u'maxWriteBatchSize': 100000, u'ok': 1.0, u'maxWireVersion': 9, u'logicalSessionTimeoutMinutes': 30, u'readOnly': False, u'topologyVersion': {u'processId': ObjectId('5e7cfc65ec9d1208376b24b9'), u'counter': 0L}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 3, 310000), u'connectionId': 5, u'isreplicaset': True, u'minWireVersion': 0, u'maxBsonObjectSize': 16777216, u'$clusterTime': {u'clusterTime': Timestamp(0, 0), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'operationTime': Timestamp(0, 0), u'maxMessageSizeBytes': 48000000, u'secondary': False}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,311 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27019, Primary(), 5)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,311 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27019
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,330 [DEBUG] mongo_orchestration.replica_sets:534 - server_info: {u'info': u'Does not have a valid replica set config', u'ismaster': False, u'maxWriteBatchSize': 100000, u'ok': 1.0, u'maxWireVersion': 9, u'logicalSessionTimeoutMinutes': 30, u'readOnly': False, u'topologyVersion': {u'processId': ObjectId('5e7cfc66707215b296ea7c40'), u'counter': 0L}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 3, 330000), u'connectionId': 5, u'isreplicaset': True, u'minWireVersion': 0, u'maxBsonObjectSize': 16777216, u'$clusterTime': {u'clusterTime': Timestamp(0, 0), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'operationTime': Timestamp(0, 0), u'maxMessageSizeBytes': 48000000, u'secondary': False}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,330 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27017, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,330 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,435 [DEBUG] mongo_orchestration.replica_sets:190 - replica init result: {u'$clusterTime': {u'clusterTime': Timestamp(1585249383, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'ok': 1.0, u'operationTime': Timestamp(1585249383, 1)}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,436 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(replSetGetStatus, None, False, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:03,436 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,011 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'term': 1L, u'set': u'repl0', u'optimes': {u'appliedOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'lastAppliedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 529000), u'lastCommittedWallTime': datetime.datetime(1970, 1, 1, 0, 0), u'durableOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'lastCommittedOpTime': {u'ts': Timestamp(0, 0), u't': -1L}, u'lastDurableWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 529000)}, u'heartbeatIntervalMillis': 2000L, u'syncSourceHost': u'', u'majorityVoteCount': 2, u'electionCandidateMetrics': {u'lastElectionDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 502000), u'numVotesNeeded': 2, u'electionTerm': 1L, u'priorityAtElection': 1.0, u'numCatchUpOps': 0L, u'lastElectionReason': u'electionTimeout', u'lastCommittedOpTimeAtElection': {u'ts': Timestamp(0, 0), u't': -1L}, u'lastSeenOpTimeAtElection': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'electionTimeoutMillis': 10000L, u'newTermStartDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000)}, u'writableVotingMembersCount': 3, u'syncSourceId': -1, u'votingMembersCount': 3, u'myState': 1, u'lastStableRecoveryTimestamp': Timestamp(0, 0), u'members': [{u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27017', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 14, 933000), u'_id': 0, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 506000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27018', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 14, 527000), u'_id': 1, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 509000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 13, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'name': u'localhost:27019', u'syncSourceHost': u'', u'infoMessage': u'could not find member to sync from', u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'syncSourceId': -1, u'electionTime': Timestamp(1585249394, 1), u'self': True, u'state': 1, u'health': 1.0, u'stateStr': u'PRIMARY', u'lastHeartbeatMessage': u'', u'_id': 2, u'electionDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'configTerm': 0}], u'$clusterTime': {u'clusterTime': Timestamp(1585249394, 5), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'date': datetime.datetime(2020, 3, 26, 19, 3, 15, 10000), u'ok': 1.0, u'operationTime': Timestamp(1585249394, 5), u'writeMajorityCount': 2}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,011 [DEBUG] mongo_orchestration.replica_sets:578 - all members in correct state
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,011 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,026 [DEBUG] mongo_orchestration.servers:289 - proc_info: {'pid': 21464, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-sMwU6F', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27017, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,040 [DEBUG] mongo_orchestration.servers:297 - server_info: {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249394, 5), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249383, 1), u'allocator': u'tcmalloc'}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,040 [DEBUG] mongo_orchestration.servers:300 - status_info: {'primary': False, 'mongos': False}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,040 [DEBUG] mongo_orchestration.servers:310 - return {'orchestration': 'servers', 'procInfo': {'pid': 21464, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-sMwU6F', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27017, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'statuses': {'primary': False, 'mongos': False}, 'mongodb_uri': 'mongodb://localhost:27017', 'serverInfo': {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249394, 5), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249383, 1), u'allocator': u'tcmalloc'}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,040 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(replSetGetStatus, None, False, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,040 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,055 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'term': 1L, u'set': u'repl0', u'optimes': {u'readConcernMajorityOpTime': {u'ts': Timestamp(1585249394, 3), u't': 1L}, u'appliedOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'lastAppliedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 529000), u'lastCommittedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000), u'readConcernMajorityWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000), u'durableOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'lastCommittedOpTime': {u'ts': Timestamp(1585249394, 3), u't': 1L}, u'lastDurableWallTime': datetime.datetime(2020, 3, 26, 19, 3, 14, 529000)}, u'heartbeatIntervalMillis': 2000L, u'syncSourceHost': u'', u'majorityVoteCount': 2, u'electionCandidateMetrics': {u'wMajorityWriteAvailabilityDate': datetime.datetime(2020, 3, 26, 19, 3, 15, 50000), u'lastElectionDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 502000), u'numVotesNeeded': 2, u'electionTerm': 1L, u'priorityAtElection': 1.0, u'numCatchUpOps': 0L, u'lastElectionReason': u'electionTimeout', u'lastCommittedOpTimeAtElection': {u'ts': Timestamp(0, 0), u't': -1L}, u'lastSeenOpTimeAtElection': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'electionTimeoutMillis': 10000L, u'newTermStartDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000)}, u'writableVotingMembersCount': 3, u'syncSourceId': -1, u'votingMembersCount': 3, u'myState': 1, u'lastStableRecoveryTimestamp': Timestamp(0, 0), u'members': [{u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27017', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 14, 933000), u'_id': 0, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 506000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27018', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 15, 27000), u'_id': 1, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 509000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 13, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249394, 5), u't': 1L}, u'name': u'localhost:27019', u'syncSourceHost': u'', u'infoMessage': u'could not find member to sync from', u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'syncSourceId': -1, u'electionTime': Timestamp(1585249394, 1), u'self': True, u'state': 1, u'health': 1.0, u'stateStr': u'PRIMARY', u'lastHeartbeatMessage': u'', u'_id': 2, u'electionDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'configTerm': 0}], u'$clusterTime': {u'clusterTime': Timestamp(1585249394, 5), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'date': datetime.datetime(2020, 3, 26, 19, 3, 15, 55000), u'ok': 1.0, u'operationTime': Timestamp(1585249394, 5), u'writeMajorityCount': 2}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,056 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(serverStatus, None, False, 0)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,056 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27017, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,056 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27017
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,070 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'metrics': {u'commands': {u'updateUser': {u'failed': 0L, u'total': 0L}, u'killAllSessions': {u'failed': 0L, u'total': 0L}, u'dropRole': {u'failed': 0L, u'total': 0L}, u'prepareTransaction': {u'failed': 0L, u'total': 0L}, u'planCacheSetFilter': {u'failed': 0L, u'total': 0L}, u'fsyncUnlock': {u'failed': 0L, u'total': 0L}, u'_configsvrDropDatabase': {u'failed': 0L, u'total': 0L}, u'usersInfo': {u'failed': 0L, u'total': 0L}, u'whatsmysni': {u'failed': 0L, u'total': 0L}, u'replSetStepDownWithForce': {u'failed': 0L, u'total': 0L}, u'makeSnapshot': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkSplit': {u'failed': 0L, u'total': 0L}, u'_configsvrMoveChunk': {u'failed': 0L, u'total': 0L}, u'abortTransaction': {u'failed': 0L, u'total': 0L}, u'_hashBSONElement': {u'failed': 0L, u'total': 0L}, u'find': {u'failed': 0L, u'total': 17L}, u'endSessions': {u'failed': 0L, u'total': 0L}, u'compact': {u'failed': 0L, u'total': 0L}, u'createIndexes': {u'failed': 0L, u'total': 0L}, u'moveChunk': {u'failed': 0L, u'total': 0L}, u'_mergeAuthzCollections': {u'failed': 0L, u'total': 0L}, u'explain': {u'failed': 0L, u'total': 0L}, u'_migrateClone': {u'failed': 0L, u'total': 0L}, u'setDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'checkShardingIndex': {u'failed': 0L, u'total': 0L}, u'<UNKNOWN>': 0L, u'_flushDatabaseCacheUpdates': {u'failed': 0L, u'total': 0L}, u'serverStatus': {u'failed': 0L, u'total': 1L}, u'replSetGetStatus': {u'failed': 0L, u'total': 0L}, u'replSetRequestVotes': {u'failed': 0L, u'total': 2L}, u'getShardMap': {u'failed': 0L, u'total': 0L}, u'grantRolesToUser': {u'failed': 0L, u'total': 0L}, u'dbCheck': {u'failed': 0L, u'total': 0L}, u'_flushRoutingTableCacheUpdates': {u'failed': 0L, u'total': 0L}, u'shardConnPoolStats': {u'failed': 0L, u'total': 0L}, u'findAndModify': {u'failed': 0L, u'total': 0L}, u'splitChunk': {u'failed': 0L, u'total': 0L}, u'planCacheClear': {u'failed': 0L, u'total': 0L}, u'getCmdLineOpts': {u'failed': 0L, u'total': 0L}, u'insert': {u'failed': 0L, u'total': 0L}, u'replSetInitiate': {u'failed': 0L, u'total': 1L}, u'replSetGetConfig': {u'failed': 0L, u'total': 0L}, u'fsync': {u'failed': 0L, u'total': 0L}, u'refreshLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'appendOplogNote': {u'failed': 0L, u'total': 0L}, u'drop': {u'failed': 0L, u'total': 0L}, u'mapreduce': {u'shardedfinish': {u'failed': 0L, u'total': 0L}}, u'_getNextSessionMods': {u'failed': 0L, u'total': 0L}, u'getDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerCollectionStatus': {u'failed': 0L, u'total': 0L}, u'_recvChunkAbort': {u'failed': 0L, u'total': 0L}, u'replSetAbortPrimaryCatchUp': {u'failed': 0L, u'total': 0L}, u'_configsvrRefineCollectionShardKey': {u'failed': 0L, u'total': 0L}, u'captrunc': {u'failed': 0L, u'total': 0L}, u'replSetSyncFrom': {u'failed': 0L, u'total': 0L}, u'_configsvrClearJumboFlag': {u'failed': 0L, u'total': 0L}, u'connectionStatus': {u'failed': 0L, u'total': 0L}, u'applyOps': {u'failed': 0L, u'total': 0L}, u'_recvChunkStatus': {u'failed': 0L, u'total': 0L}, u'replSetGetRBID': {u'failed': 0L, u'total': 4L}, u'setParameter': {u'failed': 0L, u'total': 0L}, u'startRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'dataSize': {u'failed': 0L, u'total': 0L}, u'dbHash': {u'failed': 0L, u'total': 0L}, u'_configsvrEnableSharding': {u'failed': 0L, u'total': 0L}, u'authenticate': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromRole': {u'failed': 0L, u'total': 0L}, u'grantPrivilegesToRole': {u'failed': 0L, u'total': 0L}, u'clearLog': {u'failed': 0L, u'total': 0L}, u'planCacheClearFilters': {u'failed': 0L, u'total': 0L}, u'getParameter': {u'failed': 0L, u'total': 0L}, u'dropIndexes': {u'failed': 0L, u'total': 0L}, u'listDatabases': {u'failed': 0L, u'total': 2L}, u'replSetResizeOplog': {u'failed': 0L, u'total': 0L}, u'collStats': {u'failed': 0L, u'total': 0L}, u'hostInfo': {u'failed': 0L, u'total': 0L}, u'getShardVersion': {u'failed': 0L, u'total': 0L}, u'configureFailPoint': {u'failed': 0L, u'total': 0L}, u'voteCommitIndexBuild': {u'failed': 0L, u'total': 0L}, u'dropDatabase': {u'failed': 0L, u'total': 0L}, u'dropConnections': {u'failed': 0L, u'total': 0L}, u'update': {u'failed': 0L, u'total': 0L}, u'revokePrivilegesFromRole': {u'failed': 0L, u'total': 0L}, u'logout': {u'failed': 0L, u'total': 0L}, u'reapLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'_transferMods': {u'failed': 0L, u'total': 0L}, u'_configsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'httpClientRequest': {u'failed': 0L, u'total': 0L}, u'isMaster': {u'failed': 0L, u'total': 51L}, u'collMod': {u'failed': 0L, u'total': 0L}, u'replSetReconfig': {u'failed': 0L, u'total': 0L}, u'shardingState': {u'failed': 0L, u'total': 0L}, u'getDatabaseVersion': {u'failed': 0L, u'total': 0L}, u'getLog': {u'failed': 0L, u'total': 0L}, u'listCollections': {u'failed': 0L, u'total': 2L}, u'connPoolSync': {u'failed': 0L, u'total': 0L}, u'flushRouterConfig': {u'failed': 0L, u'total': 0L}, u'replSetMaintenance': {u'failed': 0L, u'total': 0L}, u'top': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateDatabase': {u'failed': 0L, u'total': 0L}, u'replSetStepDown': {u'failed': 0L, u'total': 0L}, u'features': {u'failed': 0L, u'total': 0L}, u'replSetTest': {u'failed': 0L, u'total': 0L}, u'currentOp': {u'failed': 0L, u'total': 0L}, u'connPoolStats': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStop': {u'failed': 0L, u'total': 0L}, u'getFreeMonitoringStatus': {u'failed': 0L, u'total': 0L}, u'echo': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStatus': {u'failed': 0L, u'total': 0L}, u'_shardsvrCloneCatalogData': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShardFromZone': {u'failed': 0L, u'total': 0L}, u'planCacheListFilters': {u'failed': 0L, u'total': 0L}, u'shutdown': {u'failed': 0L, u'total': 0L}, u'refreshSessions': {u'failed': 0L, u'total': 0L}, u'getDiagnosticData': {u'failed': 0L, u'total': 0L}, u'validate': {u'failed': 0L, u'total': 0L}, u'repairDatabase': {u'failed': 0L, u'total': 0L}, u'saslStart': {u'failed': 0L, u'total': 0L}, u'distinct': {u'failed': 0L, u'total': 0L}, u'replSetFreeze': {u'failed': 0L, u'total': 0L}, u'create': {u'failed': 0L, u'total': 0L}, u'splitVector': {u'failed': 0L, u'total': 0L}, u'renameCollection': {u'failed': 0L, u'total': 0L}, u'logRotate': {u'failed': 0L, u'total': 0L}, u'_getUserCacheGeneration': {u'failed': 0L, u'total': 0L}, u'dropAllRolesFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMigration': {u'failed': 0L, u'total': 0L}, u'invalidateUserCache': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMerge': {u'failed': 0L, u'total': 0L}, u'whatsmyuri': {u'failed': 0L, u'total': 0L}, u'geoSearch': {u'failed': 0L, u'total': 0L}, u'updateRole': {u'failed': 0L, u'total': 0L}, u'_configsvrDropCollection': {u'failed': 0L, u'total': 0L}, u'logApplicationMessage': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShard': {u'failed': 0L, u'total': 0L}, u'waitForFailPoint': {u'failed': 0L, u'total': 0L}, u'killOp': {u'failed': 0L, u'total': 0L}, u'reIndex': {u'failed': 0L, u'total': 0L}, u'_isSelf': {u'failed': 0L, u'total': 2L}, u'stopRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'unsetSharding': {u'failed': 0L, u'total': 0L}, u'getnonce': {u'failed': 0L, u'total': 0L}, u'listIndexes': {u'failed': 1L, u'total': 3L}, u'sleep': {u'failed': 0L, u'total': 0L}, u'_addShard': {u'failed': 0L, u'total': 0L}, u'count': {u'failed': 0L, u'total': 2L}, u'cpuload': {u'failed': 0L, u'total': 0L}, u'filemd5': {u'failed': 0L, u'total': 0L}, u'setShardVersion': {u'failed': 0L, u'total': 0L}, u'internalRenameIfOptionsAndIndexesMatch': {u'failed': 0L, u'total': 0L}, u'commitTransaction': {u'failed': 0L, u'total': 0L}, u'startSession': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShardToZone': {u'failed': 0L, u'total': 0L}, u'_configsvrUpdateZoneKeyRange': {u'failed': 0L, u'total': 0L}, u'delete': {u'failed': 0L, u'total': 0L}, u'getMore': {u'failed': 2L, u'total': 4L}, u'rolesInfo': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromUser': {u'failed': 0L, u'total': 0L}, u'setFeatureCompatibilityVersion': {u'failed': 0L, u'total': 0L}, u'dropUser': {u'failed': 0L, u'total': 0L}, u'_killOperations': {u'failed': 0L, u'total': 0L}, u'saslContinue': {u'failed': 0L, u'total': 0L}, u'emptycapped': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShard': {u'failed': 0L, u'total': 0L}, u'_cloneCollectionOptionsFromPrimaryShard': {u'failed': 0L, u'total': 0L}, u'driverOIDTest': {u'failed': 0L, u'total': 0L}, u'getLastError': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateCollection': {u'failed': 0L, u'total': 0L}, u'waitForOngoingChunkSplits': {u'failed': 0L, u'total': 0L}, u'convertToCapped': {u'failed': 0L, u'total': 0L}, u'replSetHeartbeat': {u'failed': 0L, u'total': 51L}, u'ping': {u'failed': 0L, u'total': 0L}, u'availableQueryOptions': {u'failed': 0L, u'total': 2L}, u'dropAllUsersFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrEnsureChunkVersionIsGreaterThan': {u'failed': 0L, u'total': 0L}, u'lockInfo': {u'failed': 0L, u'total': 0L}, u'cloneCollectionAsCapped': {u'failed': 0L, u'total': 0L}, u'godinsert': {u'failed': 0L, u'total': 0L}, u'listCommands': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStart': {u'failed': 0L, u'total': 0L}, u'profile': {u'failed': 0L, u'total': 0L}, u'_shardsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'grantRolesToRole': {u'failed': 0L, u'total': 0L}, u'_recvChunkStart': {u'failed': 0L, u'total': 0L}, u'stageDebug': {u'failed': 0L, u'total': 0L}, u'killCursors': {u'failed': 0L, u'total': 0L}, u'coordinateCommitTransaction': {u'failed': 0L, u'total': 0L}, u'mapReduce': {u'failed': 0L, u'total': 0L}, u'_shardsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'setCommittedSnapshot': {u'failed': 0L, u'total': 0L}, u'createUser': {u'failed': 0L, u'total': 0L}, u'aggregate': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitMovePrimary': {u'failed': 0L, u'total': 0L}, u'replSetUpdatePosition': {u'failed': 0L, u'total': 0L}, u'replSetStepUp': {u'failed': 0L, u'total': 0L}, u'mergeChunks': {u'failed': 0L, u'total': 0L}, u'killAllSessionsByPattern': {u'failed': 0L, u'total': 0L}, u'createRole': {u'failed': 0L, u'total': 0L}, u'_configsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'killSessions': {u'failed': 0L, u'total': 0L}, u'dbStats': {u'failed': 0L, u'total': 0L}, u'_recvChunkCommit': {u'failed': 0L, u'total': 0L}, u'cleanupOrphaned': {u'failed': 0L, u'total': 0L}, u'setIndexCommitQuorum': {u'failed': 0L, u'total': 0L}, u'buildInfo': {u'failed': 0L, u'total': 1L}, u'resetError': {u'failed': 0L, u'total': 0L}}, u'aggStageCounters': {u'$_internalSplitPipeline': 0L, u'$project': 0L, u'$lookup': 0L, u'$replaceWith': 0L, u'$geoNear': 0L, u'$indexStats': 0L, u'$group': 0L, u'$skip': 0L, u'$merge': 0L, u'$set': 0L, u'$out': 0L, u'$sort': 0L, u'$unset': 0L, u'$unwind': 0L, u'$redact': 0L, u'$currentOp': 0L, u'$unionWith': 0L, u'$listSessions': 0L, u'$searchBeta': 0L, u'$sortByCount': 0L, u'$changeStream': 0L, u'$limit': 0L, u'$planCacheStats': 0L, u'$sample': 0L, u'$addFields': 0L, u'$bucketAuto': 0L, u'$listLocalSessions': 0L, u'$_internalInhibitOptimization': 0L, u'$mergeCursors': 0L, u'$facet': 0L, u'$match': 0L, u'$collStats': 0L, u'$count': 0L, u'$_internalSearchIdLookup': 0L, u'$listCachedAndActiveUsers': 0L, u'$backupCursor': 0L, u'$graphLookup': 0L, u'$replaceRoot': 0L, u'$backupCursorExtend': 0L, u'$search': 0L, u'$_internalSearchMongotRemote': 0L, u'$bucket': 0L}, u'getLastError': {u'default': {u'wtimeouts': 0L, u'unsatisfiable': 0L}, u'wtime': {u'num': 0, u'totalMillis': 0}, u'wtimeouts': 0L}, u'queryExecutor': {u'collectionScans': {u'nonTailable': 8L, u'total': 10L}, u'scanned': 2L, u'scannedObjects': 12L}, u'cursor': {u'timedOut': 0L, u'open': {u'pinned': 0L, u'total': 0L, u'noTimeout': 0L}}, u'record': {u'moves': 0L}, u'repl': {u'syncSource': {u'numSelections': 12L, u'numTimesChoseSame': 0L, u'numTimesCouldNotFind': 12L, u'numTimesChoseDifferent': 0L}, u'network': {u'ops': 0L, u'notMasterUnacknowledgedWrites': 0L, u'bytes': 0L, u'notMasterLegacyUnacknowledgedWrites': 0L, u'getmores': {u'numEmptyBatches': 0L, u'num': 0, u'totalMillis': 0}, u'replSetUpdatePosition': {u'num': 0L}, u'readersCreated': 0L, u'oplogGetMoresProcessed': {u'num': 4, u'totalMillis': 0}}, u'initialSync': {u'failures': 0L, u'completed': 0L, u'failedAttempts': 0L}, u'buffer': {u'count': 0L, u'sizeBytes': 0L, u'maxSizeBytes': 268435456L}, u'executor': {u'shuttingDown': False, u'queues': {u'sleepers': 4, u'networkInProgress': 0}, u'unsignaledEvents': 0, u'pool': {u'inProgressCount': 0}, u'networkInterface': u'DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL'}, u'stateTransition': {u'userOperationsKilled': 0L, u'lastStateTransition': u'', u'userOperationsRunning': 0L}, u'apply': {u'batchSize': 0L, u'batches': {u'num': 0, u'totalMillis': 0}, u'attemptsToBecomeSecondary': 1L, u'ops': 0L}}, u'ttl': {u'passes': 0L, u'deletedDocuments': 0L}, u'query': {u'updateOneOpStyleBroadcastWithExactIDCount': 0L, u'planCacheTotalSizeEstimateBytes': 0L}, u'operation': {u'writeConflicts': 0L, u'scanAndOrder': 0L}, u'document': {u'deleted': 0L, u'updated': 0L, u'inserted': 0L, u'returned': 12L}}, u'process': u'mongod', u'pid': 21464L, u'defaultRWConcern': {u'localUpdateWallClockTime': datetime.datetime(2020, 3, 26, 19, 3, 0, 1000)}, u'connections': {u'available': 51194, u'totalCreated': 24, u'awaitingTopologyChanges': 0, u'current': 6, u'active': 1, u'exhaustIsMaster': 0}, u'locks': {u'Database': {u'acquireCount': {u'r': 111L, u'W': 6L, u'w': 17L}}, u'Global': {u'acquireCount': {u'r': 181L, u'W': 5L, u'w': 28L}}, u'Collection': {u'acquireCount': {u'r': 56L, u'W': 2L, u'w': 10L}}, u'ParallelBatchWriterMode': {u'acquireCount': {u'r': 54L}}, u'Mutex': {u'acquireCount': {u'r': 126L, u'W': 1L}}, u'oplog': {u'acquireCount': {u'r': 62L, u'w': 2L}}, u'ReplicationStateTransition': {u'timeAcquiringMicros': {u'W': 69L, u'w': 776L}, u'acquireWaitCount': {u'W': 1L, u'w': 2L}, u'acquireCount': {u'W': 1L, u'w': 218L}}}, u'storageEngine': {u'name': u'wiredTiger', u'supportsTwoPhaseIndexBuild': True, u'persistent': True, u'dropPendingIdents': 0L, u'readOnly': False, u'supportsSnapshotReadConcern': True, u'supportsCheckpointCursors': True, u'backupCursorOpen': False, u'supportsPendingDrops': True, u'supportsCommittedReads': True, u'oldestRequiredTimestampForCrashRecovery': Timestamp(0, 0)}, u'$clusterTime': {u'clusterTime': Timestamp(1585249394, 5), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'globalLock': {u'totalTime': 15743000L, u'currentQueue': {u'total': 0, u'writers': 0, u'readers': 0}, u'activeClients': {u'total': 0, u'writers': 0, u'readers': 0}}, u'twoPhaseCommitCoordinator': {u'totalAbortedTwoPhaseCommit': 0L, u'totalStartedTwoPhaseCommit': 0L, u'totalCommittedTwoPhaseCommit': 0L, u'totalCreated': 0L, u'currentInSteps': {u'waitingForVotes': 0L, u'deletingCoordinatorDoc': 0L, u'waitingForDecisionAcks': 0L, u'writingParticipantList': 0L, u'writingDecision': 0L}}, u'opReadConcernCounters': {u'available': 0L, u'none': 13L, u'linearizable': 0L, u'majority': 0L, u'snapshot': 0L, u'local': 4L}, u'extra_info': {u'page_faults': 0L, u'voluntary_context_switches': 2040L, u'page_reclaims': 8904L, u'maximum_resident_set_kb': 126452L, u'user_time_us': 4036000L, u'note': u'fields vary by platform', u'involuntary_context_switches': 283L, u'system_time_us': 256000L, u'input_blocks': 0L, u'output_blocks': 1560L}, u'uptime': 16.0, u'network': {u'numSlowDNSOperations': 0L, u'tcpFastOpen': {u'serverSupported': True, u'accepted': 0L, u'kernelSetting': 1L, u'clientSupported': False}, u'compression': {u'zstd': {u'compressor': {u'bytesOut': 32196L, u'bytesIn': 53210L}, u'decompressor': {u'bytesOut': 48440L, u'bytesIn': 30243L}}, u'noop': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'zlib': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'snappy': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}}, u'physicalBytesIn': 25999L, u'bytesOut': 80017L, u'numRequests': 141L, u'serviceExecutorTaskStats': {u'threadsRunning': 6, u'executor': u'passthrough'}, u'physicalBytesOut': 62102L, u'numSlowSSLOperations': 0L, u'bytesIn': 31475L}, u'uptimeMillis': 15746L, u'transactions': {u'transactionsCollectionWriteCount': 0L, u'retriedCommandsCount': 0L, u'currentOpen': 0L, u'currentPrepared': 0L, u'retriedStatementsCount': 0L, u'totalPreparedThenCommitted': 0L, u'totalPrepared': 0L, u'totalAborted': 0L, u'totalCommitted': 0L, u'currentInactive': 0L, u'currentActive': 0L, u'totalStarted': 0L, u'totalPreparedThenAborted': 0L}, u'operationTime': Timestamp(1585249383, 1), u'trafficRecording': {u'running': False}, u'version': u'4.3.4', u'tcmalloc': {u'generic': {u'current_allocated_bytes': 104928000, u'heap_size': 175296512}, u'tcmalloc': {u'release_rate': 1.0, u'pageheap_unmapped_bytes': 0, u'pageheap_total_commit_bytes': 175296512, u'current_total_thread_cache_bytes': 1287032, u'central_cache_free_bytes': 329224, u'max_total_thread_cache_bytes': 979369984, u'pageheap_total_reserve_bytes': 175296512, u'total_free_bytes': 2137344, u'transfer_cache_free_bytes': 521088, u'pageheap_decommit_count': 0, u'pageheap_reserve_count': 57, u'spinlock_total_delay_ns': 2199154, u'pageheap_scavenge_count': 0, u'pageheap_committed_bytes': 175296512, u'pageheap_total_decommit_bytes': 0, u'pageheap_free_bytes': 68231168, u'pageheap_commit_count': 57, u'aggressive_memory_decommit': 0, u'formattedString': u'------------------------------------------------\nMALLOC:      104928576 (  100.1 MiB) Bytes in use by application\nMALLOC: +     68231168 (   65.1 MiB) Bytes in page heap freelist\nMALLOC: +       329224 (    0.3 MiB) Bytes in central cache freelist\nMALLOC: +       521088 (    0.5 MiB) Bytes in transfer cache freelist\nMALLOC: +      1286456 (    1.2 MiB) Bytes in thread cache freelists\nMALLOC: +      2883584 (    2.8 MiB) Bytes in malloc metadata\nMALLOC:   ------------\nMALLOC: =    178180096 (  169.9 MiB) Actual memory used (physical + swap)\nMALLOC: +            0 (    0.0 MiB) Bytes released to OS (aka unmapped)\nMALLOC:   ------------\nMALLOC: =    178180096 (  169.9 MiB) Virtual address space used\nMALLOC:\nMALLOC:           1089              Spans in use\nMALLOC:             66              Thread heaps in use\nMALLOC:           4096              Tcmalloc page size\n------------------------------------------------\nCall ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).\nBytes released to the OS take up virtual address space but no physical memory.\n', u'thread_cache_free_bytes': 1287032}}, u'electionMetrics': {u'numCatchUpsAlreadyCaughtUp': 0L, u'priorityTakeover': {u'successful': 0L, u'called': 0L}, u'numStepDownsCausedByHigherTerm': 0L, u'stepUpCmd': {u'successful': 0L, u'called': 0L}, u'catchUpTakeover': {u'successful': 0L, u'called': 0L}, u'numCatchUpsSkipped': 0L, u'numCatchUps': 0L, u'numCatchUpsSucceeded': 0L, u'electionTimeout': {u'successful': 0L, u'called': 0L}, u'averageCatchUpOps': 0.0, u'numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd': 0L, u'numCatchUpsTimedOut': 0L, u'numCatchUpsFailedWithNewTerm': 0L, u'numCatchUpsFailedWithError': 0L, u'freezeTimeout': {u'successful': 0L, u'called': 0L}}, u'mem': {u'resident': 123, u'supported': True, u'bits': 64, u'virtual': 1938}, u'opcountersRepl': {u'getmore': 0L, u'insert': 0L, u'update': 0L, u'command': 0L, u'query': 0L, u'delete': 0L}, u'wiredTiger': {u'data-handle': {u'session dhandles swept': 0, u'connection sweeps': 1, u'connection sweep dhandles removed from hash list': 0, u'connection data handles currently active': 36, u'connection data handle size': 432, u'connection sweep dhandles closed': 0, u'session sweep attempts': 53, u'connection sweep candidate became referenced': 0, u'connection sweep time-of-death sets': 31}, u'reconciliation': {u'fast-path pages deleted': 0, u'split objects currently awaiting free': 0, u'split bytes currently awaiting free': 0, u'pages deleted': 0, u'page reconciliation calls for eviction': 0, u'page reconciliation calls': 22}, u'transaction': {u'number of named snapshots dropped': 0, u'set timestamp durable calls': 0, u'read timestamp queue entries walked': 4, u'transaction checkpoint currently running': 0, u'set timestamp stable updates': 0, u'transaction begins': 75, u'transaction fsync calls for checkpoint after allocating the transaction ID': 1, u'query timestamp calls': 31, u'Number of prepared updates added to cache overflow': 0, u'read timestamp queue inserts total': 24, u'read timestamp queue insert to empty': 20, u'durable timestamp queue insert to empty': 1, u'transactions committed': 17, u'transaction checkpoint most recent time (msecs)': 18, u'set timestamp oldest calls': 0, u'transaction checkpoints': 1, u'rollback to stable calls': 0, u'set timestamp stable calls': 0, u'transaction range of IDs currently pinned by a checkpoint': 0, u'transaction range of timestamps currently pinned': 6808594255989178369L, u'durable timestamp queue inserts total': 1, u'set timestamp durable updates': 0, u'Number of prepared updates': 0, u'transaction sync calls': 0, u'durable timestamp queue entries walked': 0, u'set timestamp oldest updates': 0, u'prepared transactions rolled back': 0, u'update conflicts': 0, u'transaction checkpoint scrub time (msecs)': 0, u'transaction fsync duration for checkpoint after allocating the transaction ID (usecs)': 13077, u'prepared transactions committed': 0, u'read timestamp queue length': 1, u'transaction checkpoint max time (msecs)': 18, u'transaction checkpoints skipped because database was clean': 0, u'transaction checkpoint scrub dirty target': 0, u'rollback to stable updates removed from cache overflow': 0, u'durable timestamp queue inserts to head': 0, u'number of named snapshots created': 0, u'transaction range of timestamps pinned by the oldest timestamp': 6808594255989178369L, u'transaction range of timestamps pinned by a checkpoint': 6808594255989178369L, u'read timestamp queue inserts to head': 4, u'durable timestamp queue length': 1, u'transaction checkpoint min time (msecs)': 18, u'prepared transactions': 0, u'transaction checkpoint total time (msecs)': 18, u'rollback to stable updates aborted': 0, u'transaction checkpoint generation': 2, u'transaction range of timestamps pinned by the oldest active read timestamp': 0, u'transaction read timestamp of the oldest active reader': 0, u'set timestamp calls': 0, u'prepared transactions currently active': 0, u'transaction range of IDs currently pinned by named snapshots': 0, u'transactions rolled back': 58, u'transaction failures due to cache overflow': 0, u'transaction range of IDs currently pinned': 0}, u'capacity': {u'bytes read': 0, u'time waiting due to total capacity (usecs)': 0, u'background fsync file handles synced': 0, u'time waiting during read (usecs)': 0, u'bytes written for eviction': 0, u'time waiting during checkpoint (usecs)': 0, u'time waiting during eviction (usecs)': 0, u'bytes written total': 57460, u'bytes written for checkpoint': 25588, u'background fsync file handles considered': 0, u'time waiting during logging (usecs)': 0, u'bytes written for log': 31872, u'background fsync time (msecs)': 0, u'threshold to call fsync': 0}, u'log': {u'slot join calls yielded': 0, u'log sync_dir operations': 1, u'log sync operations': 24, u'log write operations': 80, u'log server thread advances write LSN': 4, u'slot unbuffered writes': 0, u'maximum log file size': 104857600, u'log scan records requiring two reads': 0, u'slot transitions unable to find free slot': 0, u'records processed by log scan': 0, u'total log buffer size': 33554432, u'slot close unbuffered waits': 0, u'log records too small to compress': 26, u'log force write operations skipped': 173, u'log scan operations': 0, u'pre-allocated log files used': 0, u'pre-allocated log files not ready and missed': 1, u'total size of compressed records': 16751, u'pre-allocated log files prepared': 2, u'log sync time duration (usecs)': 16931, u'total in-memory size of compressed records': 34641, u'yields waiting for previous log file close': 0, u'slot close lost race': 0, u'log records not compressed': 33, u'slot join calls did not yield': 80, u'log force write operations': 177, u'slot join calls slept': 0, u'written slots coalesced': 0, u'slot join atomic update races': 0, u'slot join calls found active slot closed': 0, u'log records compressed': 21, u'number of pre-allocated log files to create': 2, u'log bytes written': 31744, u'slot join calls atomic updates raced': 0, u'busy returns attempting to switch slots': 0, u'log files manually zero-filled': 0, u'log bytes of payload data': 23769, u'log flush operations': 152, u'log sync_dir time duration (usecs)': 0, u'force archive time sleeping (usecs)': 0, u'slot closures': 24, u'log server thread write LSN walk skipped': 2005, u'log release advances write LSN': 20, u'slot joins yield time (usecs)': 0, u'slot join found active slot closed': 0, u'logging bytes consolidated': 31232}, u'lock': {u'durable timestamp queue write lock acquisitions': 1, u'table lock internal thread time waiting for the table lock (usecs)': 0, u'dhandle read lock acquisitions': 76, u'checkpoint lock application thread wait time (usecs)': 0, u'metadata lock application thread wait time (usecs)': 0, u'dhandle lock application thread time waiting (usecs)': 0, u'metadata lock acquisitions': 1, u'table lock application thread time waiting for the table lock (usecs)': 0, u'dhandle write lock acquisitions': 36, u'durable timestamp queue lock application thread time waiting (usecs)': 0, u'read timestamp queue write lock acquisitions': 24, u'read timestamp queue lock internal thread time waiting (usecs)': 0, u'metadata lock internal thread wait time (usecs)': 0, u'read timestamp queue lock application thread time waiting (usecs)': 0, u'txn global write lock acquisitions': 8, u'checkpoint lock acquisitions': 1, u'table write lock acquisitions': 42, u'txn global read lock acquisitions': 9, u'table read lock acquisitions': 0, u'schema lock application thread wait time (usecs)': 0, u'checkpoint lock internal thread wait time (usecs)': 0, u'schema lock acquisitions': 21, u'txn global lock internal thread time waiting (usecs)': 0, u'dhandle lock internal thread time waiting (usecs)': 0, u'txn global lock application thread time waiting (usecs)': 0, u'read timestamp queue read lock acquisitions': 0, u'durable timestamp queue read lock acquisitions': 0, u'schema lock internal thread wait time (usecs)': 0, u'durable timestamp queue lock internal thread time waiting (usecs)': 0}, u'cache': {u'eviction server evicting pages': 0, u'pages seen by eviction walk that are already queued': 0, u'tracked dirty pages in the cache': 8, u'eviction walk target strategy both clean and dirty pages': 0, u'cache overflow cursor application thread wait time (usecs)': 0, u'hazard pointer check entries walked': 0, u'page split during eviction deepened the tree': 0, u'pages walked for eviction': 0, u'tracked dirty bytes in the cache': 58536, u'internal pages queued for eviction': 0, u'eviction worker thread stable number': 0, u'eviction walks started from saved location in tree': 0, u'checkpoint blocked page eviction': 0, u'tracked bytes belonging to internal pages in the cache': 6467, u'page written requiring cache overflow records': 0, u'pages queued for urgent eviction': 0, u'overflow pages read into cache': 0, u'pages written from cache': 22, u'eviction walk target pages histogram - 0-9': 0, u'pages selected for eviction unable to be evicted because of failure in reconciliation': 0, u'hazard pointer blocked page eviction': 0, u'cache overflow table insert calls': 0, u'eviction walk target strategy only clean pages': 0, u'files with new eviction walks started': 0, u'in-memory page splits': 0, u'unmodified pages evicted': 0, u'maximum bytes configured': 3383754752.0, u'modified pages evicted': 0, u'eviction server unable to reach eviction goal': 0, u'forced eviction - pages evicted that were clean time (usecs)': 0, u'pages read into cache requiring cache overflow for checkpoint': 0, u'pages read into cache after truncate in prepare state': 0, u'internal pages split during eviction': 0, u'application threads page write from cache to disk time (usecs)': 460, u'eviction walks gave up because they saw too many pages and found no candidates': 0, u'forced eviction - pages selected unable to be evicted time': 0, u'percentage overhead': 8, u'pages evicted by application threads': 0, u'eviction walk target strategy only dirty pages': 0, u'forced eviction - pages selected because of too many deleted items count': 0, u'forced eviction - pages evicted that were dirty count': 0, u'eviction walks reached end of tree': 0, u'application threads page read from disk to cache time (usecs)': 0, u'eviction currently operating in aggressive mode': 0, u'in-memory page passed criteria to be split': 0, u'eviction state': 128, u'force re-tuning of eviction workers once in a while': 0, u'eviction calls to get a page': 2, u'pages seen by eviction walk': 0, u'pages read into cache with skipped cache overflow entries needed later': 0, u'bytes not belonging to page images in the cache': 75293, u'pages selected for eviction unable to be evicted because of active children on an internal page': 0, u'eviction walk target pages histogram - 128 and higher': 0, u'pages read into cache': 0, u'eviction walks gave up because they restarted their walk twice': 0, u'pages written requiring in-memory restoration': 0, u'eviction worker thread active': 4, u'pages requested from the cache': 569, u'eviction server candidate queue not empty when topping up': 0, u'bytes belonging to page images in the cache': 0, u'internal pages evicted': 0, u'eviction calls to get a page found queue empty after locking': 0, u'forced eviction - pages selected unable to be evicted count': 0, u'internal pages seen by eviction walk that are already queued': 0, u'maximum page size at eviction': 0, u'bytes belonging to the cache overflow table in the cache': 182, u'eviction server candidate queue empty when topping up': 0, u'eviction empty score': 0, u'eviction server slept, because we did not make progress with eviction': 0, u'eviction walks abandoned': 0, u'pages read into cache after truncate': 16, u'application threads page read from disk to cache count': 0, u'bytes currently in the cache': 75293, u'pages selected for eviction unable to be evicted': 0, u'hazard pointer maximum array length': 0, u'operations timed out waiting for space in cache': 0, u'eviction walks started from root of tree': 0, u'tracked bytes belonging to leaf pages in the cache': 68826, u'modified pages evicted by application threads': 0, u'pages queued for eviction': 0, u'pages read into cache requiring cache overflow entries': 0, u'eviction worker thread removed': 0, u'forced eviction - pages selected count': 0, u'files with active eviction walks': 0, u'forced eviction - pages evicted that were clean count': 0, u'cache overflow table on-disk size': 0, u'eviction worker thread created': 0, u'pages selected for eviction unable to be evicted due to newer modifications on a clean page': 0, u'pages currently held in the cache': 35, u'hazard pointer check calls': 0, u'internal pages seen by eviction walk': 0, u'eviction walk target pages histogram - 32-63': 0, u'cache overflow table max on-disk size': 0, u'bytes dirty in the cache cumulative': 20878, u'application threads page write from cache to disk count': 22, u'eviction calls to get a page found queue empty': 2, u'eviction walks gave up because they saw too many pages and found too few candidates': 0, u'bytes written from cache': 26149, u'pages read into cache skipping older cache overflow entries': 0, u'cache overflow score': 0, u'pages queued for urgent eviction during walk': 0, u'forced eviction - pages evicted that were dirty time (usecs)': 0, u'pages read into cache with skipped cache overflow entries needed later by checkpoint': 0, u'eviction worker thread evicting pages': 0, u'bytes read into cache': 0, u'eviction server waiting for a leaf page': 0, u'cache overflow cursor internal thread wait time (usecs)': 0, u'eviction walk target pages histogram - 10-31': 0, u'pages selected for eviction unable to be evicted as the parent page has overflow items': 0, u'eviction passes of a file': 0, u'leaf pages split during eviction': 0, u'pages queued for eviction post lru sorting': 0, u'cache overflow table remove calls': 0, u'cache overflow table entries': 0, u'eviction walk target pages histogram - 64-128': 0}, u'uri': u'statistics:', u'snapshot-window-settings': {u'target available snapshots window size in seconds': 5, u'latest majority snapshot timestamp available': u'Jan  1 00:00:00:0', u'total number of SnapshotTooOld errors': 0L, u'oldest majority snapshot timestamp available': u'Jan  1 00:00:00:0', u'current available snapshots window size in seconds': 0, u'cache pressure percentage threshold': 95, u'max target available snapshots window size in seconds': 5, u'current cache pressure percentage': 0L}, u'cursor': {u'cursor truncate calls': 0, u'cursor update key and value bytes': 0, u'cached cursor count': 37, u'cursor sweeps': 1, u'cursor update value size change': 0, u'cursor search calls': 438, u'cursor next calls': 70, u'cursor modify calls': 0, u'cursor sweep cursors examined': 0, u'cursor reserve calls': 0, u'cursor sweep cursors closed': 0, u'open cursor count': 26, u'cursor search near calls': 8, u'cursor sweep buckets': 6, u'cursor remove calls': 0, u'cursors reused from cache': 43, u'cursor update calls': 0, u'cursor insert key and value bytes': 47416, u'cursor insert calls': 108, u'cursor reset calls': 651, u'cursor bulk loaded cursor insert calls': 0, u'cursor modify value bytes modified': 0, u'cursor prev calls': 17, u'cursor operation restarted': 0, u'cursor modify key and value bytes affected': 0, u'cursor remove key bytes removed': 0, u'cursor close calls that result in cache': 80, u'cursor create calls': 170}, u'connection': {u'total read I/Os': 25, u'memory re-allocations': 696, u'pthread mutex shared lock write-lock calls': 164, u'auto adjusting condition resets': 7, u'detected system time went backwards': 0, u'pthread mutex condition wait calls': 291, u'memory frees': 5994, u'pthread mutex shared lock read-lock calls': 975, u'total fsync I/Os': 68, u'files currently open': 22, u'memory allocations': 7557, u'auto adjusting condition wait calls': 126, u'total write I/Os': 93}, u'session': {u'table import failed calls': 0, u'table compact failed calls': 0, u'table create successful calls': 17, u'table rebalance successful calls': 0, u'table alter successful calls': 0, u'session query timestamp calls': 0, u'table rebalance failed calls': 0, u'table salvage failed calls': 0, u'table truncate failed calls': 0, u'table rename successful calls': 0, u'table verify successful calls': 0, u'table drop failed calls': 0, u'open session count': 22, u'table verify failed calls': 0, u'table alter failed calls': 0, u'table import successful calls': 0, u'table compact successful calls': 0, u'table drop successful calls': 0, u'table alter unchanged and skipped': 0, u'table salvage successful calls': 0, u'table truncate successful calls': 0, u'table create failed calls': 0, u'table rename failed calls': 0}, u'block-manager': {u'bytes read': 0, u'blocks read': 0, u'blocks pre-loaded': 0, u'bytes written': 196608, u'mapped bytes read': 0, u'bytes written for checkpoint': 196608, u'blocks written': 44, u'mapped blocks read': 0}, u'thread-yield': {u'page acquire busy blocked': 0, u'page acquire time sleeping (usecs)': 0, u'data handle lock yielded': 0, u'connection close blocked waiting for transaction state stabilization': 0, u'connection close yielded for lsm manager shutdown': 0, u'application thread time evicting (usecs)': 0, u'page delete rollback time sleeping for state change (usecs)': 0, u'get reference for page index and slot time sleeping (usecs)': 0, u'page acquire read blocked': 0, u'log server sync yielded for log write': 0, u'page acquire locked blocked': 0, u'page reconciliation yielded due to child modification': 0, u'page acquire eviction blocked': 0, u'application thread time waiting for cache (usecs)': 0, u'page access yielded due to prepare state change': 0}, u'async': {u'total insert calls': 0, u'total remove calls': 0, u'number of operation slots viewed for allocation': 0, u'total allocations': 0, u'current work queue length': 0, u'number of flush calls': 0, u'maximum work queue length': 0, u'total compact calls': 0, u'total update calls': 0, u'number of allocation state races': 0, u'number of times operation allocation failed': 0, u'number of times worker found no work': 0, u'total search calls': 0}, u'concurrentTransactions': {u'write': {u'available': 128, u'totalTickets': 128, u'out': 0}, u'read': {u'available': 127, u'totalTickets': 128, u'out': 1}}, u'thread-state': {u'active filesystem write calls': 0, u'active filesystem read calls': 0, u'active filesystem fsync calls': 0}, u'perf': {u'file system write latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 4) - 1000-9999us': 0, u'operation read latency histogram (bucket 1) - 100-249us': 0, u'file system read latency histogram (bucket 4) - 250-499ms': 0, u'operation write latency histogram (bucket 4) - 1000-9999us': 0, u'file system write latency histogram (bucket 3) - 100-249ms': 0, u'file system read latency histogram (bucket 3) - 100-249ms': 0, u'operation write latency histogram (bucket 1) - 100-249us': 0, u'file system write latency histogram (bucket 2) - 50-99ms': 0, u'file system read latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 3) - 500-999us': 0, u'operation write latency histogram (bucket 5) - 10000us+': 0, u'operation read latency histogram (bucket 2) - 250-499us': 0, u'operation write latency histogram (bucket 3) - 500-999us': 0, u'operation read latency histogram (bucket 5) - 10000us+': 0, u'operation write latency histogram (bucket 2) - 250-499us': 0, u'file system read latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 1) - 10-49ms': 0, u'file system read latency histogram (bucket 1) - 10-49ms': 0, u'file system write latency histogram (bucket 4) - 250-499ms': 0, u'file system read latency histogram (bucket 2) - 50-99ms': 0}}, u'opLatencies': {u'commands': {u'latency': 92788L, u'ops': 120L}, u'reads': {u'latency': 1908L, u'ops': 20L}, u'writes': {u'latency': 0L, u'ops': 0L}, u'transactions': {u'latency': 0L, u'ops': 0L}}, u'uptimeEstimate': 15L, u'host': u'ip-10-122-0-207', u'repl': {u'me': u'localhost:27017', u'ismaster': False, u'setName': u'repl0', u'tags': {u'ordinal': u'one', u'dc': u'ny'}, u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc637437028946f5530b'), u'counter': 3L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'opTime': {u'ts': Timestamp(1585249383, 1), u't': -1L}}, u'setVersion': 1, u'secondary': True}, u'encryptionAtRest': {u'encryptionEnabled': False}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 68000), u'opcounters': {u'getmore': 4L, u'insert': 0L, u'update': 0L, u'command': 124L, u'query': 17L, u'delete': 0L}, u'oplogTruncation': {u'truncateCount': 0L, u'totalTimeTruncatingMicros': 0L, u'processingMethod': u'scanning', u'totalTimeProcessingMicros': 29L}, u'ok': 1.0, u'logicalSessionRecordCache': {u'lastTransactionReaperJobDurationMillis': 0, u'sessionCatalogSize': 0, u'lastTransactionReaperJobEntriesCleanedUp': 0, u'transactionReaperJobCount': 1, u'lastSessionsCollectionJobDurationMillis': 0, u'sessionsCollectionJobCount': 1, u'lastSessionsCollectionJobEntriesEnded': 0, u'lastSessionsCollectionJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 0, 39000), u'lastTransactionReaperJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 0, 39000), u'lastSessionsCollectionJobEntriesRefreshed': 0, u'activeSessionsCount': 0, u'lastSessionsCollectionJobCursorsClosed': 0}, u'flowControl': {u'isLaggedTimeMicros': 0L, u'timeAcquiringMicros': 17L, u'locksPerKiloOp': 0.0, u'enabled': True, u'isLagged': False, u'sustainerRate': 0, u'targetRateLimit': 1000000000, u'isLaggedCount': 0}, u'asserts': {u'msg': 0, u'rollovers': 0, u'regular': 0, u'warning': 0, u'user': 21}, u'transportSecurity': {u'unknown': 0L, u'1.0': 0L, u'1.1': 0L, u'1.2': 27L, u'1.3': 0L}, u'security': {u'authentication': {u'mechanisms': {u'SCRAM-SHA-256': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'SCRAM-SHA-1': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'MONGODB-X509': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}}}, u'SSLServerSubjectName': u'C=US,ST=New York,L=New York City,O=MongoDB,OU=Drivers,CN=localhost', u'SSLServerHasCertificateAuthority': True, u'SSLServerCertificateExpirationDate': datetime.datetime(2039, 5, 22, 22, 32, 56)}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,071 [DEBUG] mongo_orchestration.replica_sets:375 - member 0 repl info: {u'me': u'localhost:27017', u'ismaster': False, u'setName': u'repl0', u'tags': {u'ordinal': u'one', u'dc': u'ny'}, u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc637437028946f5530b'), u'counter': 3L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'opTime': {u'ts': Timestamp(1585249383, 1), u't': -1L}}, u'setVersion': 1, u'secondary': True}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,071 [DEBUG] mongo_orchestration.replica_sets:599 - real_member_info(0): {'server_id': '3070b0d6-b447-478f-b034-b38665b5a03f', 'procInfo': {'pid': 21464, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-sMwU6F', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27017, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-ZbxLgk'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'mongodb_uri': 'mongodb://localhost:27017', '_id': 0, 'mongodb_auth_uri': u'mongodb://bob:pwd123@localhost:27017/?authSource=admin', 'statuses': {'primary': False, 'mongos': False}, 'rsInfo': {'secondary': True, 'primary': False, 'tags': {u'ordinal': u'one', u'dc': u'ny'}}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,071 [DEBUG] mongo_orchestration.servers:289 - proc_info: {'pid': 21510, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-uxWLDA', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27018, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,083 [DEBUG] mongo_orchestration.servers:297 - server_info: {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249395, 1), u'allocator': u'tcmalloc'}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,084 [DEBUG] mongo_orchestration.servers:300 - status_info: {'primary': False, 'mongos': False}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,084 [DEBUG] mongo_orchestration.servers:310 - return {'orchestration': 'servers', 'procInfo': {'pid': 21510, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-uxWLDA', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27018, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'statuses': {'primary': False, 'mongos': False}, 'mongodb_uri': 'mongodb://localhost:27018', 'serverInfo': {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249395, 1), u'allocator': u'tcmalloc'}}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,084 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(replSetGetStatus, None, False, None)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,084 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,094 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'term': 1L, u'set': u'repl0', u'optimes': {u'readConcernMajorityOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'appliedOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastAppliedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'lastCommittedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'readConcernMajorityWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'durableOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastCommittedOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastDurableWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000)}, u'heartbeatIntervalMillis': 2000L, u'syncSourceHost': u'', u'majorityVoteCount': 2, u'electionCandidateMetrics': {u'wMajorityWriteAvailabilityDate': datetime.datetime(2020, 3, 26, 19, 3, 15, 50000), u'lastElectionDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 502000), u'numVotesNeeded': 2, u'electionTerm': 1L, u'priorityAtElection': 1.0, u'numCatchUpOps': 0L, u'lastElectionReason': u'electionTimeout', u'lastCommittedOpTimeAtElection': {u'ts': Timestamp(0, 0), u't': -1L}, u'lastSeenOpTimeAtElection': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'electionTimeoutMillis': 10000L, u'newTermStartDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000)}, u'writableVotingMembersCount': 3, u'syncSourceId': -1, u'votingMembersCount': 3, u'myState': 1, u'lastStableRecoveryTimestamp': Timestamp(1585249394, 3), u'members': [{u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27017', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 14, 933000), u'_id': 0, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 506000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27018', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 15, 27000), u'_id': 1, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 509000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 13, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'name': u'localhost:27019', u'syncSourceHost': u'', u'infoMessage': u'could not find member to sync from', u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'syncSourceId': -1, u'electionTime': Timestamp(1585249394, 1), u'self': True, u'state': 1, u'health': 1.0, u'stateStr': u'PRIMARY', u'lastHeartbeatMessage': u'', u'_id': 2, u'electionDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'configTerm': 0}], u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'date': datetime.datetime(2020, 3, 26, 19, 3, 15, 94000), u'ok': 1.0, u'operationTime': Timestamp(1585249395, 1), u'writeMajorityCount': 2}
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,094 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(serverStatus, None, False, 1)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,095 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27018, Primary(), 300)
 [2020/03/26 19:03:17.139] 2020-03-26 19:03:15,095 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27018
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,109 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'metrics': {u'commands': {u'updateUser': {u'failed': 0L, u'total': 0L}, u'killAllSessions': {u'failed': 0L, u'total': 0L}, u'dropRole': {u'failed': 0L, u'total': 0L}, u'prepareTransaction': {u'failed': 0L, u'total': 0L}, u'planCacheSetFilter': {u'failed': 0L, u'total': 0L}, u'fsyncUnlock': {u'failed': 0L, u'total': 0L}, u'_configsvrDropDatabase': {u'failed': 0L, u'total': 0L}, u'usersInfo': {u'failed': 0L, u'total': 0L}, u'whatsmysni': {u'failed': 0L, u'total': 0L}, u'replSetStepDownWithForce': {u'failed': 0L, u'total': 0L}, u'makeSnapshot': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkSplit': {u'failed': 0L, u'total': 0L}, u'_configsvrMoveChunk': {u'failed': 0L, u'total': 0L}, u'abortTransaction': {u'failed': 0L, u'total': 0L}, u'_hashBSONElement': {u'failed': 0L, u'total': 0L}, u'find': {u'failed': 0L, u'total': 4L}, u'endSessions': {u'failed': 0L, u'total': 0L}, u'compact': {u'failed': 0L, u'total': 0L}, u'createIndexes': {u'failed': 0L, u'total': 0L}, u'moveChunk': {u'failed': 0L, u'total': 0L}, u'_mergeAuthzCollections': {u'failed': 0L, u'total': 0L}, u'explain': {u'failed': 0L, u'total': 0L}, u'_migrateClone': {u'failed': 0L, u'total': 0L}, u'setDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'checkShardingIndex': {u'failed': 0L, u'total': 0L}, u'<UNKNOWN>': 0L, u'_flushDatabaseCacheUpdates': {u'failed': 0L, u'total': 0L}, u'serverStatus': {u'failed': 0L, u'total': 1L}, u'replSetGetStatus': {u'failed': 0L, u'total': 0L}, u'replSetRequestVotes': {u'failed': 0L, u'total': 2L}, u'getShardMap': {u'failed': 0L, u'total': 0L}, u'grantRolesToUser': {u'failed': 0L, u'total': 0L}, u'dbCheck': {u'failed': 0L, u'total': 0L}, u'_flushRoutingTableCacheUpdates': {u'failed': 0L, u'total': 0L}, u'shardConnPoolStats': {u'failed': 0L, u'total': 0L}, u'findAndModify': {u'failed': 0L, u'total': 0L}, u'splitChunk': {u'failed': 0L, u'total': 0L}, u'planCacheClear': {u'failed': 0L, u'total': 0L}, u'getCmdLineOpts': {u'failed': 0L, u'total': 0L}, u'insert': {u'failed': 0L, u'total': 0L}, u'replSetInitiate': {u'failed': 0L, u'total': 0L}, u'replSetGetConfig': {u'failed': 0L, u'total': 0L}, u'fsync': {u'failed': 0L, u'total': 0L}, u'refreshLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'appendOplogNote': {u'failed': 0L, u'total': 0L}, u'drop': {u'failed': 0L, u'total': 0L}, u'mapreduce': {u'shardedfinish': {u'failed': 0L, u'total': 0L}}, u'_getNextSessionMods': {u'failed': 0L, u'total': 0L}, u'getDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerCollectionStatus': {u'failed': 0L, u'total': 0L}, u'_recvChunkAbort': {u'failed': 0L, u'total': 0L}, u'replSetAbortPrimaryCatchUp': {u'failed': 0L, u'total': 0L}, u'_configsvrRefineCollectionShardKey': {u'failed': 0L, u'total': 0L}, u'captrunc': {u'failed': 0L, u'total': 0L}, u'replSetSyncFrom': {u'failed': 0L, u'total': 0L}, u'_configsvrClearJumboFlag': {u'failed': 0L, u'total': 0L}, u'connectionStatus': {u'failed': 0L, u'total': 0L}, u'applyOps': {u'failed': 0L, u'total': 0L}, u'_recvChunkStatus': {u'failed': 0L, u'total': 0L}, u'replSetGetRBID': {u'failed': 0L, u'total': 0L}, u'setParameter': {u'failed': 0L, u'total': 0L}, u'startRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'dataSize': {u'failed': 0L, u'total': 0L}, u'dbHash': {u'failed': 0L, u'total': 0L}, u'_configsvrEnableSharding': {u'failed': 0L, u'total': 0L}, u'authenticate': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromRole': {u'failed': 0L, u'total': 0L}, u'grantPrivilegesToRole': {u'failed': 0L, u'total': 0L}, u'clearLog': {u'failed': 0L, u'total': 0L}, u'planCacheClearFilters': {u'failed': 0L, u'total': 0L}, u'getParameter': {u'failed': 0L, u'total': 0L}, u'dropIndexes': {u'failed': 0L, u'total': 0L}, u'listDatabases': {u'failed': 0L, u'total': 0L}, u'replSetResizeOplog': {u'failed': 0L, u'total': 0L}, u'collStats': {u'failed': 0L, u'total': 0L}, u'hostInfo': {u'failed': 0L, u'total': 0L}, u'getShardVersion': {u'failed': 0L, u'total': 0L}, u'configureFailPoint': {u'failed': 0L, u'total': 0L}, u'voteCommitIndexBuild': {u'failed': 0L, u'total': 0L}, u'dropDatabase': {u'failed': 0L, u'total': 0L}, u'dropConnections': {u'failed': 0L, u'total': 0L}, u'update': {u'failed': 0L, u'total': 0L}, u'revokePrivilegesFromRole': {u'failed': 0L, u'total': 0L}, u'logout': {u'failed': 0L, u'total': 0L}, u'reapLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'_transferMods': {u'failed': 0L, u'total': 0L}, u'_configsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'httpClientRequest': {u'failed': 0L, u'total': 0L}, u'isMaster': {u'failed': 0L, u'total': 44L}, u'collMod': {u'failed': 0L, u'total': 0L}, u'replSetReconfig': {u'failed': 0L, u'total': 0L}, u'shardingState': {u'failed': 0L, u'total': 0L}, u'getDatabaseVersion': {u'failed': 0L, u'total': 0L}, u'getLog': {u'failed': 0L, u'total': 0L}, u'listCollections': {u'failed': 0L, u'total': 0L}, u'connPoolSync': {u'failed': 0L, u'total': 0L}, u'flushRouterConfig': {u'failed': 0L, u'total': 0L}, u'replSetMaintenance': {u'failed': 0L, u'total': 0L}, u'top': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateDatabase': {u'failed': 0L, u'total': 0L}, u'replSetStepDown': {u'failed': 0L, u'total': 0L}, u'features': {u'failed': 0L, u'total': 0L}, u'replSetTest': {u'failed': 0L, u'total': 0L}, u'currentOp': {u'failed': 0L, u'total': 0L}, u'connPoolStats': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStop': {u'failed': 0L, u'total': 0L}, u'getFreeMonitoringStatus': {u'failed': 0L, u'total': 0L}, u'echo': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStatus': {u'failed': 0L, u'total': 0L}, u'_shardsvrCloneCatalogData': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShardFromZone': {u'failed': 0L, u'total': 0L}, u'planCacheListFilters': {u'failed': 0L, u'total': 0L}, u'shutdown': {u'failed': 0L, u'total': 0L}, u'refreshSessions': {u'failed': 0L, u'total': 0L}, u'getDiagnosticData': {u'failed': 0L, u'total': 0L}, u'validate': {u'failed': 0L, u'total': 0L}, u'repairDatabase': {u'failed': 0L, u'total': 0L}, u'saslStart': {u'failed': 0L, u'total': 0L}, u'distinct': {u'failed': 0L, u'total': 0L}, u'replSetFreeze': {u'failed': 0L, u'total': 0L}, u'create': {u'failed': 0L, u'total': 0L}, u'splitVector': {u'failed': 0L, u'total': 0L}, u'renameCollection': {u'failed': 0L, u'total': 0L}, u'logRotate': {u'failed': 0L, u'total': 0L}, u'_getUserCacheGeneration': {u'failed': 0L, u'total': 0L}, u'dropAllRolesFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMigration': {u'failed': 0L, u'total': 0L}, u'invalidateUserCache': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMerge': {u'failed': 0L, u'total': 0L}, u'whatsmyuri': {u'failed': 0L, u'total': 0L}, u'geoSearch': {u'failed': 0L, u'total': 0L}, u'updateRole': {u'failed': 0L, u'total': 0L}, u'_configsvrDropCollection': {u'failed': 0L, u'total': 0L}, u'logApplicationMessage': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShard': {u'failed': 0L, u'total': 0L}, u'waitForFailPoint': {u'failed': 0L, u'total': 0L}, u'killOp': {u'failed': 0L, u'total': 0L}, u'reIndex': {u'failed': 0L, u'total': 0L}, u'_isSelf': {u'failed': 0L, u'total': 2L}, u'stopRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'unsetSharding': {u'failed': 0L, u'total': 0L}, u'getnonce': {u'failed': 0L, u'total': 0L}, u'listIndexes': {u'failed': 1L, u'total': 1L}, u'sleep': {u'failed': 0L, u'total': 0L}, u'_addShard': {u'failed': 0L, u'total': 0L}, u'count': {u'failed': 0L, u'total': 0L}, u'cpuload': {u'failed': 0L, u'total': 0L}, u'filemd5': {u'failed': 0L, u'total': 0L}, u'setShardVersion': {u'failed': 0L, u'total': 0L}, u'internalRenameIfOptionsAndIndexesMatch': {u'failed': 0L, u'total': 0L}, u'commitTransaction': {u'failed': 0L, u'total': 0L}, u'startSession': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShardToZone': {u'failed': 0L, u'total': 0L}, u'_configsvrUpdateZoneKeyRange': {u'failed': 0L, u'total': 0L}, u'delete': {u'failed': 0L, u'total': 0L}, u'getMore': {u'failed': 0L, u'total': 0L}, u'rolesInfo': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromUser': {u'failed': 0L, u'total': 0L}, u'setFeatureCompatibilityVersion': {u'failed': 0L, u'total': 0L}, u'dropUser': {u'failed': 0L, u'total': 0L}, u'_killOperations': {u'failed': 0L, u'total': 0L}, u'saslContinue': {u'failed': 0L, u'total': 0L}, u'emptycapped': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShard': {u'failed': 0L, u'total': 0L}, u'_cloneCollectionOptionsFromPrimaryShard': {u'failed': 0L, u'total': 0L}, u'driverOIDTest': {u'failed': 0L, u'total': 0L}, u'getLastError': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateCollection': {u'failed': 0L, u'total': 0L}, u'waitForOngoingChunkSplits': {u'failed': 0L, u'total': 0L}, u'convertToCapped': {u'failed': 0L, u'total': 0L}, u'replSetHeartbeat': {u'failed': 0L, u'total': 48L}, u'ping': {u'failed': 0L, u'total': 0L}, u'availableQueryOptions': {u'failed': 0L, u'total': 0L}, u'dropAllUsersFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrEnsureChunkVersionIsGreaterThan': {u'failed': 0L, u'total': 0L}, u'lockInfo': {u'failed': 0L, u'total': 0L}, u'cloneCollectionAsCapped': {u'failed': 0L, u'total': 0L}, u'godinsert': {u'failed': 0L, u'total': 0L}, u'listCommands': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStart': {u'failed': 0L, u'total': 0L}, u'profile': {u'failed': 0L, u'total': 0L}, u'_shardsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'grantRolesToRole': {u'failed': 0L, u'total': 0L}, u'_recvChunkStart': {u'failed': 0L, u'total': 0L}, u'stageDebug': {u'failed': 0L, u'total': 0L}, u'killCursors': {u'failed': 0L, u'total': 0L}, u'coordinateCommitTransaction': {u'failed': 0L, u'total': 0L}, u'mapReduce': {u'failed': 0L, u'total': 0L}, u'_shardsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'setCommittedSnapshot': {u'failed': 0L, u'total': 0L}, u'createUser': {u'failed': 0L, u'total': 0L}, u'aggregate': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitMovePrimary': {u'failed': 0L, u'total': 0L}, u'replSetUpdatePosition': {u'failed': 0L, u'total': 0L}, u'replSetStepUp': {u'failed': 0L, u'total': 0L}, u'mergeChunks': {u'failed': 0L, u'total': 0L}, u'killAllSessionsByPattern': {u'failed': 0L, u'total': 0L}, u'createRole': {u'failed': 0L, u'total': 0L}, u'_configsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'killSessions': {u'failed': 0L, u'total': 0L}, u'dbStats': {u'failed': 0L, u'total': 0L}, u'_recvChunkCommit': {u'failed': 0L, u'total': 0L}, u'cleanupOrphaned': {u'failed': 0L, u'total': 0L}, u'setIndexCommitQuorum': {u'failed': 0L, u'total': 0L}, u'buildInfo': {u'failed': 0L, u'total': 1L}, u'resetError': {u'failed': 0L, u'total': 0L}}, u'aggStageCounters': {u'$_internalSplitPipeline': 0L, u'$project': 0L, u'$lookup': 0L, u'$replaceWith': 0L, u'$geoNear': 0L, u'$indexStats': 0L, u'$group': 0L, u'$skip': 0L, u'$merge': 0L, u'$set': 0L, u'$out': 0L, u'$sort': 0L, u'$unset': 0L, u'$unwind': 0L, u'$redact': 0L, u'$currentOp': 0L, u'$unionWith': 0L, u'$listSessions': 0L, u'$searchBeta': 0L, u'$sortByCount': 0L, u'$changeStream': 0L, u'$limit': 0L, u'$planCacheStats': 0L, u'$sample': 0L, u'$addFields': 0L, u'$bucketAuto': 0L, u'$listLocalSessions': 0L, u'$_internalInhibitOptimization': 0L, u'$mergeCursors': 0L, u'$facet': 0L, u'$match': 0L, u'$collStats': 0L, u'$count': 0L, u'$_internalSearchIdLookup': 0L, u'$listCachedAndActiveUsers': 0L, u'$backupCursor': 0L, u'$graphLookup': 0L, u'$replaceRoot': 0L, u'$backupCursorExtend': 0L, u'$search': 0L, u'$_internalSearchMongotRemote': 0L, u'$bucket': 0L}, u'getLastError': {u'default': {u'wtimeouts': 0L, u'unsatisfiable': 0L}, u'wtime': {u'num': 0, u'totalMillis': 0}, u'wtimeouts': 0L}, u'queryExecutor': {u'collectionScans': {u'nonTailable': 0L, u'total': 0L}, u'scanned': 0L, u'scannedObjects': 0L}, u'cursor': {u'timedOut': 0L, u'open': {u'pinned': 0L, u'total': 0L, u'noTimeout': 0L}}, u'record': {u'moves': 0L}, u'repl': {u'syncSource': {u'numSelections': 12L, u'numTimesChoseSame': 0L, u'numTimesCouldNotFind': 11L, u'numTimesChoseDifferent': 1L}, u'network': {u'ops': 7L, u'notMasterUnacknowledgedWrites': 0L, u'bytes': 1081L, u'notMasterLegacyUnacknowledgedWrites': 0L, u'getmores': {u'numEmptyBatches': 0L, u'num': 3, u'totalMillis': 22}, u'replSetUpdatePosition': {u'num': 11L}, u'readersCreated': 3L, u'oplogGetMoresProcessed': {u'num': 0, u'totalMillis': 0}}, u'initialSync': {u'failures': 0L, u'completed': 1L, u'failedAttempts': 0L}, u'buffer': {u'count': 0L, u'sizeBytes': 0L, u'maxSizeBytes': 268435456L}, u'executor': {u'shuttingDown': False, u'queues': {u'sleepers': 4, u'networkInProgress': 0}, u'unsignaledEvents': 0, u'pool': {u'inProgressCount': 0}, u'networkInterface': u'DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL'}, u'stateTransition': {u'userOperationsKilled': 0L, u'lastStateTransition': u'', u'userOperationsRunning': 0L}, u'apply': {u'batchSize': 5L, u'batches': {u'num': 5, u'totalMillis': 18}, u'attemptsToBecomeSecondary': 1L, u'ops': 5L}}, u'ttl': {u'passes': 0L, u'deletedDocuments': 0L}, u'query': {u'updateOneOpStyleBroadcastWithExactIDCount': 0L, u'planCacheTotalSizeEstimateBytes': 0L}, u'operation': {u'writeConflicts': 0L, u'scanAndOrder': 0L}, u'document': {u'deleted': 0L, u'updated': 0L, u'inserted': 0L, u'returned': 0L}}, u'process': u'mongod', u'pid': 21510L, u'defaultRWConcern': {u'localUpdateWallClockTime': datetime.datetime(2020, 3, 26, 19, 3, 1, 695000)}, u'connections': {u'available': 51196, u'totalCreated': 18, u'awaitingTopologyChanges': 0, u'current': 4, u'active': 1, u'exhaustIsMaster': 0}, u'locks': {u'Database': {u'acquireCount': {u'r': 100L, u'W': 13L, u'w': 55L}}, u'Global': {u'acquireCount': {u'r': 133L, u'W': 5L, u'w': 72L}}, u'Collection': {u'acquireCount': {u'r': 55L, u'W': 6L, u'w': 40L}}, u'ParallelBatchWriterMode': {u'acquireCount': {u'r': 74L, u'W': 5L}}, u'Mutex': {u'acquireCount': {u'r': 165L, u'W': 3L}}, u'oplog': {u'acquireCount': {u'r': 55L, u'W': 1L, u'w': 8L}}, u'ReplicationStateTransition': {u'timeAcquiringMicros': {u'w': 219L}, u'acquireWaitCount': {u'w': 2L}, u'acquireCount': {u'W': 1L, u'w': 210L}}}, u'storageEngine': {u'name': u'wiredTiger', u'supportsTwoPhaseIndexBuild': True, u'persistent': True, u'dropPendingIdents': 0L, u'readOnly': False, u'supportsSnapshotReadConcern': True, u'supportsCheckpointCursors': True, u'backupCursorOpen': False, u'supportsPendingDrops': True, u'supportsCommittedReads': True, u'oldestRequiredTimestampForCrashRecovery': Timestamp(1585249394, 5)}, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'globalLock': {u'totalTime': 14037000L, u'currentQueue': {u'total': 0, u'writers': 0, u'readers': 0}, u'activeClients': {u'total': 0, u'writers': 0, u'readers': 0}}, u'twoPhaseCommitCoordinator': {u'totalAbortedTwoPhaseCommit': 0L, u'totalStartedTwoPhaseCommit': 0L, u'totalCommittedTwoPhaseCommit': 0L, u'totalCreated': 0L, u'currentInSteps': {u'waitingForVotes': 0L, u'deletingCoordinatorDoc': 0L, u'waitingForDecisionAcks': 0L, u'writingParticipantList': 0L, u'writingDecision': 0L}}, u'opReadConcernCounters': {u'available': 0L, u'none': 4L, u'linearizable': 0L, u'majority': 0L, u'snapshot': 0L, u'local': 0L}, u'extra_info': {u'page_faults': 0L, u'voluntary_context_switches': 2174L, u'page_reclaims': 9525L, u'maximum_resident_set_kb': 138860L, u'user_time_us': 2832000L, u'note': u'fields vary by platform', u'involuntary_context_switches': 555L, u'system_time_us': 204000L, u'input_blocks': 0L, u'output_blocks': 2288L}, u'uptime': 14.0, u'network': {u'numSlowDNSOperations': 0L, u'tcpFastOpen': {u'serverSupported': True, u'accepted': 0L, u'kernelSetting': 1L, u'clientSupported': False}, u'compression': {u'zstd': {u'compressor': {u'bytesOut': 32020L, u'bytesIn': 55098L}, u'decompressor': {u'bytesOut': 53891L, u'bytesIn': 32675L}}, u'noop': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'zlib': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'snappy': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}}, u'physicalBytesIn': 17070L, u'bytesOut': 60834L, u'numRequests': 98L, u'serviceExecutorTaskStats': {u'threadsRunning': 4, u'executor': u'passthrough'}, u'physicalBytesOut': 48965L, u'numSlowSSLOperations': 0L, u'bytesIn': 20397L}, u'uptimeMillis': 14039L, u'transactions': {u'transactionsCollectionWriteCount': 0L, u'retriedCommandsCount': 0L, u'currentOpen': 0L, u'currentPrepared': 0L, u'retriedStatementsCount': 0L, u'totalPreparedThenCommitted': 0L, u'totalPrepared': 0L, u'totalAborted': 0L, u'totalCommitted': 0L, u'currentInactive': 0L, u'currentActive': 0L, u'totalStarted': 0L, u'totalPreparedThenAborted': 0L}, u'operationTime': Timestamp(1585249395, 1), u'trafficRecording': {u'running': False}, u'version': u'4.3.4', u'tcmalloc': {u'generic': {u'current_allocated_bytes': 105441920, u'heap_size': 112103424}, u'tcmalloc': {u'release_rate': 1.0, u'pageheap_unmapped_bytes': 0, u'pageheap_total_commit_bytes': 112103424, u'current_total_thread_cache_bytes': 2042376, u'central_cache_free_bytes': 271800, u'max_total_thread_cache_bytes': 979369984, u'pageheap_total_reserve_bytes': 112103424, u'total_free_bytes': 2749824, u'transfer_cache_free_bytes': 435648, u'pageheap_decommit_count': 0, u'pageheap_reserve_count': 57, u'spinlock_total_delay_ns': 0, u'pageheap_scavenge_count': 0, u'pageheap_committed_bytes': 112103424, u'pageheap_total_decommit_bytes': 0, u'pageheap_free_bytes': 3911680, u'pageheap_commit_count': 57, u'aggressive_memory_decommit': 0, u'formattedString': u'------------------------------------------------\nMALLOC:      105442496 (  100.6 MiB) Bytes in use by application\nMALLOC: +      3911680 (    3.7 MiB) Bytes in page heap freelist\nMALLOC: +       271800 (    0.3 MiB) Bytes in central cache freelist\nMALLOC: +       435648 (    0.4 MiB) Bytes in transfer cache freelist\nMALLOC: +      2041800 (    1.9 MiB) Bytes in thread cache freelists\nMALLOC: +      2883584 (    2.8 MiB) Bytes in malloc metadata\nMALLOC:   ------------\nMALLOC: =    114987008 (  109.7 MiB) Actual memory used (physical + swap)\nMALLOC: +            0 (    0.0 MiB) Bytes released to OS (aka unmapped)\nMALLOC:   ------------\nMALLOC: =    114987008 (  109.7 MiB) Virtual address space used\nMALLOC:\nMALLOC:           1191              Spans in use\nMALLOC:             69              Thread heaps in use\nMALLOC:           4096              Tcmalloc page size\n------------------------------------------------\nCall ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).\nBytes released to the OS take up virtual address space but no physical memory.\n', u'thread_cache_free_bytes': 2042376}}, u'electionMetrics': {u'numCatchUpsAlreadyCaughtUp': 0L, u'priorityTakeover': {u'successful': 0L, u'called': 0L}, u'numStepDownsCausedByHigherTerm': 0L, u'stepUpCmd': {u'successful': 0L, u'called': 0L}, u'catchUpTakeover': {u'successful': 0L, u'called': 0L}, u'numCatchUpsSkipped': 0L, u'numCatchUps': 0L, u'numCatchUpsSucceeded': 0L, u'electionTimeout': {u'successful': 0L, u'called': 0L}, u'averageCatchUpOps': 0.0, u'numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd': 0L, u'numCatchUpsTimedOut': 0L, u'numCatchUpsFailedWithNewTerm': 0L, u'numCatchUpsFailedWithError': 0L, u'freezeTimeout': {u'successful': 0L, u'called': 0L}}, u'mem': {u'resident': 135, u'supported': True, u'bits': 64, u'virtual': 1913}, u'opcountersRepl': {u'getmore': 0L, u'insert': 2L, u'update': 0L, u'command': 2L, u'query': 0L, u'delete': 0L}, u'wiredTiger': {u'data-handle': {u'session dhandles swept': 2, u'connection sweeps': 7, u'connection sweep dhandles removed from hash list': 4, u'connection data handles currently active': 58, u'connection data handle size': 432, u'connection sweep dhandles closed': 6, u'session sweep attempts': 79, u'connection sweep candidate became referenced': 0, u'connection sweep time-of-death sets': 50}, u'reconciliation': {u'fast-path pages deleted': 0, u'split objects currently awaiting free': 0, u'split bytes currently awaiting free': 0, u'pages deleted': 0, u'page reconciliation calls for eviction': 1, u'page reconciliation calls': 47}, u'transaction': {u'number of named snapshots dropped': 0, u'set timestamp durable calls': 1, u'read timestamp queue entries walked': 0, u'transaction checkpoint currently running': 0, u'set timestamp stable updates': 1, u'transaction begins': 116, u'transaction fsync calls for checkpoint after allocating the transaction ID': 2, u'query timestamp calls': 27, u'Number of prepared updates added to cache overflow': 0, u'read timestamp queue inserts total': 1, u'read timestamp queue insert to empty': 1, u'durable timestamp queue insert to empty': 4, u'transactions committed': 60, u'transaction checkpoint most recent time (msecs)': 16, u'set timestamp oldest calls': 2, u'transaction checkpoints': 2, u'rollback to stable calls': 0, u'set timestamp stable calls': 1, u'transaction range of IDs currently pinned by a checkpoint': 0, u'transaction range of timestamps currently pinned': 25769803772.0, u'durable timestamp queue inserts total': 21, u'set timestamp durable updates': 1, u'Number of prepared updates': 0, u'transaction sync calls': 0, u'durable timestamp queue entries walked': 17, u'set timestamp oldest updates': 2, u'prepared transactions rolled back': 0, u'update conflicts': 0, u'transaction checkpoint scrub time (msecs)': 0, u'transaction fsync duration for checkpoint after allocating the transaction ID (usecs)': 11991, u'prepared transactions committed': 0, u'read timestamp queue length': 1, u'transaction checkpoint max time (msecs)': 20, u'transaction checkpoints skipped because database was clean': 0, u'transaction checkpoint scrub dirty target': 0, u'rollback to stable updates removed from cache overflow': 0, u'durable timestamp queue inserts to head': 17, u'number of named snapshots created': 0, u'transaction range of timestamps pinned by the oldest timestamp': 25769803772.0, u'transaction range of timestamps pinned by a checkpoint': 6808594307528785921L, u'read timestamp queue inserts to head': 0, u'durable timestamp queue length': 1, u'transaction checkpoint min time (msecs)': 16, u'prepared transactions': 0, u'transaction checkpoint total time (msecs)': 36, u'rollback to stable updates aborted': 0, u'transaction checkpoint generation': 3, u'transaction range of timestamps pinned by the oldest active read timestamp': 0, u'transaction read timestamp of the oldest active reader': 0, u'set timestamp calls': 3, u'prepared transactions currently active': 0, u'transaction range of IDs currently pinned by named snapshots': 0, u'transactions rolled back': 56, u'transaction failures due to cache overflow': 0, u'transaction range of IDs currently pinned': 0}, u'capacity': {u'bytes read': 8192, u'time waiting due to total capacity (usecs)': 0, u'background fsync file handles synced': 0, u'time waiting during read (usecs)': 0, u'bytes written for eviction': 74, u'time waiting during checkpoint (usecs)': 0, u'time waiting during eviction (usecs)': 0, u'bytes written total': 124392, u'bytes written for checkpoint': 69022, u'background fsync file handles considered': 0, u'time waiting during logging (usecs)': 0, u'bytes written for log': 55296, u'background fsync time (msecs)': 0, u'threshold to call fsync': 0}, u'log': {u'slot join calls yielded': 0, u'log sync_dir operations': 1, u'log sync operations': 49, u'log write operations': 168, u'log server thread advances write LSN': 12, u'slot unbuffered writes': 0, u'maximum log file size': 104857600, u'log scan records requiring two reads': 0, u'slot transitions unable to find free slot': 0, u'records processed by log scan': 0, u'total log buffer size': 33554432, u'slot close unbuffered waits': 0, u'log records too small to compress': 75, u'log force write operations skipped': 160, u'log scan operations': 0, u'pre-allocated log files used': 0, u'pre-allocated log files not ready and missed': 1, u'total size of compressed records': 27265, u'pre-allocated log files prepared': 2, u'log sync time duration (usecs)': 38372, u'total in-memory size of compressed records': 62929, u'yields waiting for previous log file close': 0, u'slot close lost race': 0, u'log records not compressed': 58, u'slot join calls did not yield': 168, u'log force write operations': 172, u'slot join calls slept': 0, u'written slots coalesced': 0, u'slot join atomic update races': 0, u'slot join calls found active slot closed': 0, u'log records compressed': 35, u'number of pre-allocated log files to create': 2, u'log bytes written': 55168, u'slot join calls atomic updates raced': 0, u'busy returns attempting to switch slots': 1099, u'log files manually zero-filled': 0, u'log bytes of payload data': 39932, u'log flush operations': 148, u'log sync_dir time duration (usecs)': 1, u'force archive time sleeping (usecs)': 0, u'slot closures': 49, u'log server thread write LSN walk skipped': 2004, u'log release advances write LSN': 37, u'slot joins yield time (usecs)': 0, u'slot join found active slot closed': 0, u'logging bytes consolidated': 54656}, u'lock': {u'durable timestamp queue write lock acquisitions': 21, u'table lock internal thread time waiting for the table lock (usecs)': 0, u'dhandle read lock acquisitions': 119, u'checkpoint lock application thread wait time (usecs)': 0, u'metadata lock application thread wait time (usecs)': 0, u'dhandle lock application thread time waiting (usecs)': 0, u'metadata lock acquisitions': 2, u'table lock application thread time waiting for the table lock (usecs)': 7000, u'dhandle write lock acquisitions': 72, u'durable timestamp queue lock application thread time waiting (usecs)': 0, u'read timestamp queue write lock acquisitions': 1, u'read timestamp queue lock internal thread time waiting (usecs)': 0, u'metadata lock internal thread wait time (usecs)': 0, u'read timestamp queue lock application thread time waiting (usecs)': 0, u'txn global write lock acquisitions': 24, u'checkpoint lock acquisitions': 2, u'table write lock acquisitions': 60, u'txn global read lock acquisitions': 61, u'table read lock acquisitions': 0, u'schema lock application thread wait time (usecs)': 0, u'checkpoint lock internal thread wait time (usecs)': 0, u'schema lock acquisitions': 41, u'txn global lock internal thread time waiting (usecs)': 0, u'dhandle lock internal thread time waiting (usecs)': 0, u'txn global lock application thread time waiting (usecs)': 0, u'read timestamp queue read lock acquisitions': 0, u'durable timestamp queue read lock acquisitions': 0, u'schema lock internal thread wait time (usecs)': 0, u'durable timestamp queue lock internal thread time waiting (usecs)': 0}, u'cache': {u'eviction server evicting pages': 0, u'pages seen by eviction walk that are already queued': 0, u'tracked dirty pages in the cache': 7, u'eviction walk target strategy both clean and dirty pages': 0, u'cache overflow cursor application thread wait time (usecs)': 0, u'hazard pointer check entries walked': 0, u'page split during eviction deepened the tree': 0, u'pages walked for eviction': 0, u'tracked dirty bytes in the cache': 93921, u'internal pages queued for eviction': 0, u'eviction worker thread stable number': 0, u'eviction walks started from saved location in tree': 0, u'checkpoint blocked page eviction': 0, u'tracked bytes belonging to internal pages in the cache': 9553, u'page written requiring cache overflow records': 0, u'pages queued for urgent eviction': 0, u'overflow pages read into cache': 0, u'pages written from cache': 48, u'eviction walk target pages histogram - 0-9': 0, u'pages selected for eviction unable to be evicted because of failure in reconciliation': 0, u'hazard pointer blocked page eviction': 0, u'cache overflow table insert calls': 0, u'eviction walk target strategy only clean pages': 0, u'files with new eviction walks started': 0, u'in-memory page splits': 0, u'unmodified pages evicted': 0, u'maximum bytes configured': 3383754752.0, u'modified pages evicted': 2, u'eviction server unable to reach eviction goal': 0, u'forced eviction - pages evicted that were clean time (usecs)': 0, u'pages read into cache requiring cache overflow for checkpoint': 0, u'pages read into cache after truncate in prepare state': 0, u'internal pages split during eviction': 0, u'application threads page write from cache to disk time (usecs)': 955, u'eviction walks gave up because they saw too many pages and found no candidates': 0, u'forced eviction - pages selected unable to be evicted time': 0, u'percentage overhead': 8, u'pages evicted by application threads': 0, u'eviction walk target strategy only dirty pages': 0, u'forced eviction - pages selected because of too many deleted items count': 0, u'forced eviction - pages evicted that were dirty count': 0, u'eviction walks reached end of tree': 0, u'application threads page read from disk to cache time (usecs)': 2, u'eviction currently operating in aggressive mode': 0, u'in-memory page passed criteria to be split': 0, u'eviction state': 128, u'force re-tuning of eviction workers once in a while': 0, u'eviction calls to get a page': 7, u'pages seen by eviction walk': 0, u'pages read into cache with skipped cache overflow entries needed later': 0, u'bytes not belonging to page images in the cache': 118163, u'pages selected for eviction unable to be evicted because of active children on an internal page': 0, u'eviction walk target pages histogram - 128 and higher': 0, u'pages read into cache': 2, u'eviction walks gave up because they restarted their walk twice': 0, u'pages written requiring in-memory restoration': 0, u'eviction worker thread active': 4, u'pages requested from the cache': 1015, u'eviction server candidate queue not empty when topping up': 0, u'bytes belonging to page images in the cache': 135, u'internal pages evicted': 0, u'eviction calls to get a page found queue empty after locking': 0, u'forced eviction - pages selected unable to be evicted count': 0, u'internal pages seen by eviction walk that are already queued': 0, u'maximum page size at eviction': 0, u'bytes belonging to the cache overflow table in the cache': 182, u'eviction server candidate queue empty when topping up': 0, u'eviction empty score': 0, u'eviction server slept, because we did not make progress with eviction': 0, u'eviction walks abandoned': 0, u'pages read into cache after truncate': 21, u'application threads page read from disk to cache count': 1, u'bytes currently in the cache': 118298, u'pages selected for eviction unable to be evicted': 0, u'hazard pointer maximum array length': 0, u'operations timed out waiting for space in cache': 0, u'eviction walks started from root of tree': 0, u'tracked bytes belonging to leaf pages in the cache': 108745, u'modified pages evicted by application threads': 0, u'pages queued for eviction': 0, u'pages read into cache requiring cache overflow entries': 0, u'eviction worker thread removed': 0, u'forced eviction - pages selected count': 0, u'files with active eviction walks': 0, u'forced eviction - pages evicted that were clean count': 0, u'cache overflow table on-disk size': 0, u'eviction worker thread created': 0, u'pages selected for eviction unable to be evicted due to newer modifications on a clean page': 0, u'pages currently held in the cache': 43, u'hazard pointer check calls': 0, u'internal pages seen by eviction walk': 0, u'eviction walk target pages histogram - 32-63': 0, u'cache overflow table max on-disk size': 0, u'bytes dirty in the cache cumulative': 35066, u'application threads page write from cache to disk count': 48, u'eviction calls to get a page found queue empty': 7, u'eviction walks gave up because they saw too many pages and found too few candidates': 0, u'bytes written from cache': 70320, u'pages read into cache skipping older cache overflow entries': 0, u'cache overflow score': 0, u'pages queued for urgent eviction during walk': 0, u'forced eviction - pages evicted that were dirty time (usecs)': 0, u'pages read into cache with skipped cache overflow entries needed later by checkpoint': 0, u'eviction worker thread evicting pages': 0, u'bytes read into cache': 125, u'eviction server waiting for a leaf page': 5, u'cache overflow cursor internal thread wait time (usecs)': 0, u'eviction walk target pages histogram - 10-31': 0, u'pages selected for eviction unable to be evicted as the parent page has overflow items': 0, u'eviction passes of a file': 0, u'leaf pages split during eviction': 0, u'pages queued for eviction post lru sorting': 0, u'cache overflow table remove calls': 0, u'cache overflow table entries': 0, u'eviction walk target pages histogram - 64-128': 0}, u'uri': u'statistics:', u'snapshot-window-settings': {u'target available snapshots window size in seconds': 5, u'latest majority snapshot timestamp available': u'Mar 26 19:03:14:5', u'total number of SnapshotTooOld errors': 0L, u'oldest majority snapshot timestamp available': u'Mar 26 19:03:09:5', u'current available snapshots window size in seconds': 5, u'cache pressure percentage threshold': 95, u'max target available snapshots window size in seconds': 5, u'current cache pressure percentage': 0L}, u'cursor': {u'cursor truncate calls': 0, u'cursor update key and value bytes': 0, u'cached cursor count': 52, u'cursor sweeps': 3, u'cursor update value size change': 0, u'cursor search calls': 750, u'cursor next calls': 83, u'cursor modify calls': 21, u'cursor sweep cursors examined': 0, u'cursor reserve calls': 0, u'cursor sweep cursors closed': 0, u'open cursor count': 25, u'cursor search near calls': 35, u'cursor sweep buckets': 18, u'cursor remove calls': 20, u'cursors reused from cache': 68, u'cursor update calls': 0, u'cursor insert key and value bytes': 82902, u'cursor insert calls': 184, u'cursor reset calls': 1144, u'cursor bulk loaded cursor insert calls': 1, u'cursor modify value bytes modified': 296, u'cursor prev calls': 14, u'cursor operation restarted': 0, u'cursor modify key and value bytes affected': 1590, u'cursor remove key bytes removed': 692, u'cursor close calls that result in cache': 120, u'cursor create calls': 237}, u'connection': {u'total read I/Os': 45, u'memory re-allocations': 1017, u'pthread mutex shared lock write-lock calls': 285, u'auto adjusting condition resets': 59, u'detected system time went backwards': 0, u'pthread mutex condition wait calls': 327, u'memory frees': 10470, u'pthread mutex shared lock read-lock calls': 1591, u'total fsync I/Os': 122, u'files currently open': 26, u'memory allocations': 12549, u'auto adjusting condition wait calls': 167, u'total write I/Os': 181}, u'session': {u'table import failed calls': 0, u'table compact failed calls': 0, u'table create successful calls': 27, u'table rebalance successful calls': 0, u'table alter successful calls': 0, u'session query timestamp calls': 0, u'table rebalance failed calls': 0, u'table salvage failed calls': 0, u'table truncate failed calls': 0, u'table rename successful calls': 0, u'table verify successful calls': 0, u'table drop failed calls': 0, u'open session count': 21, u'table verify failed calls': 0, u'table alter failed calls': 0, u'table import successful calls': 0, u'table compact successful calls': 0, u'table drop successful calls': 6, u'table alter unchanged and skipped': 0, u'table salvage successful calls': 0, u'table truncate successful calls': 0, u'table create failed calls': 0, u'table rename failed calls': 0}, u'block-manager': {u'bytes read': 28672, u'blocks read': 7, u'blocks pre-loaded': 1, u'bytes written': 442368, u'mapped bytes read': 0, u'bytes written for checkpoint': 438272, u'blocks written': 96, u'mapped blocks read': 0}, u'thread-yield': {u'page acquire busy blocked': 0, u'page acquire time sleeping (usecs)': 0, u'data handle lock yielded': 0, u'connection close blocked waiting for transaction state stabilization': 0, u'connection close yielded for lsm manager shutdown': 0, u'application thread time evicting (usecs)': 0, u'page delete rollback time sleeping for state change (usecs)': 0, u'get reference for page index and slot time sleeping (usecs)': 0, u'page acquire read blocked': 0, u'log server sync yielded for log write': 0, u'page acquire locked blocked': 0, u'page reconciliation yielded due to child modification': 0, u'page acquire eviction blocked': 0, u'application thread time waiting for cache (usecs)': 0, u'page access yielded due to prepare state change': 0}, u'async': {u'total insert calls': 0, u'total remove calls': 0, u'number of operation slots viewed for allocation': 0, u'total allocations': 0, u'current work queue length': 0, u'number of flush calls': 0, u'maximum work queue length': 0, u'total compact calls': 0, u'total update calls': 0, u'number of allocation state races': 0, u'number of times operation allocation failed': 0, u'number of times worker found no work': 0, u'total search calls': 0}, u'concurrentTransactions': {u'write': {u'available': 128, u'totalTickets': 128, u'out': 0}, u'read': {u'available': 127, u'totalTickets': 128, u'out': 1}}, u'thread-state': {u'active filesystem write calls': 0, u'active filesystem read calls': 0, u'active filesystem fsync calls': 0}, u'perf': {u'file system write latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 4) - 1000-9999us': 0, u'operation read latency histogram (bucket 1) - 100-249us': 0, u'file system read latency histogram (bucket 4) - 250-499ms': 0, u'operation write latency histogram (bucket 4) - 1000-9999us': 0, u'file system write latency histogram (bucket 3) - 100-249ms': 0, u'file system read latency histogram (bucket 3) - 100-249ms': 0, u'operation write latency histogram (bucket 1) - 100-249us': 0, u'file system write latency histogram (bucket 2) - 50-99ms': 0, u'file system read latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 3) - 500-999us': 0, u'operation write latency histogram (bucket 5) - 10000us+': 0, u'operation read latency histogram (bucket 2) - 250-499us': 0, u'operation write latency histogram (bucket 3) - 500-999us': 0, u'operation read latency histogram (bucket 5) - 10000us+': 0, u'operation write latency histogram (bucket 2) - 250-499us': 0, u'file system read latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 1) - 10-49ms': 0, u'file system read latency histogram (bucket 1) - 10-49ms': 0, u'file system write latency histogram (bucket 4) - 250-499ms': 0, u'file system read latency histogram (bucket 2) - 50-99ms': 0}}, u'opLatencies': {u'commands': {u'latency': 5144L, u'ops': 97L}, u'reads': {u'latency': 0L, u'ops': 0L}, u'writes': {u'latency': 0L, u'ops': 0L}, u'transactions': {u'latency': 0L, u'ops': 0L}}, u'uptimeEstimate': 14L, u'host': u'ip-10-122-0-207:27018', u'repl': {u'me': u'localhost:27018', u'ismaster': False, u'setName': u'repl0', u'tags': {u'ordinal': u'two', u'dc': u'pa'}, u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc65ec9d1208376b24b9'), u'counter': 3L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'majorityWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'opTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'majorityOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}}, u'setVersion': 1, u'secondary': True}, u'encryptionAtRest': {u'encryptionEnabled': False}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 107000), u'opcounters': {u'getmore': 0L, u'insert': 0L, u'update': 0L, u'command': 99L, u'query': 4L, u'delete': 0L}, u'oplogTruncation': {u'truncateCount': 0L, u'totalTimeTruncatingMicros': 0L, u'processingMethod': u'scanning', u'totalTimeProcessingMicros': 21L}, u'ok': 1.0, u'logicalSessionRecordCache': {u'lastTransactionReaperJobDurationMillis': 0, u'sessionCatalogSize': 0, u'lastTransactionReaperJobEntriesCleanedUp': 0, u'transactionReaperJobCount': 1, u'lastSessionsCollectionJobDurationMillis': 0, u'sessionsCollectionJobCount': 1, u'lastSessionsCollectionJobEntriesEnded': 0, u'lastSessionsCollectionJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 1, 742000), u'lastTransactionReaperJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 1, 742000), u'lastSessionsCollectionJobEntriesRefreshed': 0, u'activeSessionsCount': 0, u'lastSessionsCollectionJobCursorsClosed': 0}, u'flowControl': {u'isLaggedTimeMicros': 0L, u'timeAcquiringMicros': 26L, u'locksPerKiloOp': 0.0, u'enabled': True, u'isLagged': False, u'sustainerRate': 0, u'targetRateLimit': 1000000000, u'isLaggedCount': 0}, u'asserts': {u'msg': 0, u'rollovers': 0, u'regular': 0, u'warning': 0, u'user': 27}, u'transportSecurity': {u'unknown': 0L, u'1.0': 0L, u'1.1': 0L, u'1.2': 27L, u'1.3': 0L}, u'security': {u'authentication': {u'mechanisms': {u'SCRAM-SHA-256': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'SCRAM-SHA-1': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'MONGODB-X509': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}}}, u'SSLServerSubjectName': u'C=US,ST=New York,L=New York City,O=MongoDB,OU=Drivers,CN=localhost', u'SSLServerHasCertificateAuthority': True, u'SSLServerCertificateExpirationDate': datetime.datetime(2039, 5, 22, 22, 32, 56)}}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,109 [DEBUG] mongo_orchestration.replica_sets:375 - member 1 repl info: {u'me': u'localhost:27018', u'ismaster': False, u'setName': u'repl0', u'tags': {u'ordinal': u'two', u'dc': u'pa'}, u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc65ec9d1208376b24b9'), u'counter': 3L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'majorityWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'opTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'majorityOpTime': {u'ts': Timestamp(1585249394, 5), u't': 1L}}, u'setVersion': 1, u'secondary': True}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,109 [DEBUG] mongo_orchestration.replica_sets:599 - real_member_info(1): {'server_id': 'd733352b-18bb-4367-a157-a2ca7efd89b3', 'procInfo': {'pid': 21510, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-uxWLDA', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw/mongod.log', 'enableMajorityReadConcern': True, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslOnNormalPorts': True, 'oplogSize': 500, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'port': 27018, u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-Gpn2qw'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'mongodb_uri': 'mongodb://localhost:27018', '_id': 1, 'mongodb_auth_uri': u'mongodb://bob:pwd123@localhost:27018/?authSource=admin', 'statuses': {'primary': False, 'mongos': False}, 'rsInfo': {'secondary': True, 'primary': False, 'tags': {u'ordinal': u'two', u'dc': u'pa'}}}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,109 [DEBUG] mongo_orchestration.servers:289 - proc_info: {'pid': 21556, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-aofXMz', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ/mongod.log', 'enableMajorityReadConcern': True, u'port': 27019, u'sslOnNormalPorts': True, 'oplogSize': 100, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,118 [DEBUG] mongo_orchestration.servers:297 - server_info: {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249395, 1), u'allocator': u'tcmalloc'}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,118 [DEBUG] mongo_orchestration.servers:300 - status_info: {'primary': True, 'mongos': False}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,118 [DEBUG] mongo_orchestration.servers:310 - return {'orchestration': 'servers', 'procInfo': {'pid': 21556, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-aofXMz', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ/mongod.log', 'enableMajorityReadConcern': True, u'port': 27019, u'sslOnNormalPorts': True, 'oplogSize': 100, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'statuses': {'primary': True, 'mongos': False}, 'mongodb_uri': 'mongodb://localhost:27019', 'serverInfo': {u'storageEngines': [u'biggie', u'devnull', u'ephemeralForTest', u'inMemory', u'queryable_wt', u'wiredTiger'], u'maxBsonObjectSize': 16777216, u'ok': 1.0, u'bits': 64, u'modules': [u'enterprise'], u'openssl': {u'compiled': u'OpenSSL 1.0.2g  1 Mar 2016', u'running': u'OpenSSL 1.0.2g  1 Mar 2016'}, u'javascriptEngine': u'mozjs', u'version': u'4.3.4', u'gitVersion': u'56655b06ac46825c5937ccca5947dc84ccbca69c', u'versionArray': [4, 3, 4, 0], u'debug': False, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'buildEnvironment': {u'cxxflags': u'-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17', u'cc': u'/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.2.0', u'linkflags': u'-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags', u'cppdefines': u'SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG ABSL_FORCE_ALIGNED_ACCESS', u'distarch': u'x86_64', u'cxx': u'/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.2.0', u'ccflags': u'-fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp', u'target_arch': u'x86_64', u'distmod': u'ubuntu1604', u'target_os': u'linux'}, u'sysInfo': u'deprecated', u'operationTime': Timestamp(1585249395, 1), u'allocator': u'tcmalloc'}}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,118 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(replSetGetStatus, None, False, None)
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,118 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,134 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'term': 1L, u'set': u'repl0', u'optimes': {u'readConcernMajorityOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'appliedOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastAppliedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'lastCommittedWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'readConcernMajorityWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000), u'durableOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastCommittedOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'lastDurableWallTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 60000)}, u'heartbeatIntervalMillis': 2000L, u'syncSourceHost': u'', u'majorityVoteCount': 2, u'electionCandidateMetrics': {u'wMajorityWriteAvailabilityDate': datetime.datetime(2020, 3, 26, 19, 3, 15, 50000), u'lastElectionDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 502000), u'numVotesNeeded': 2, u'electionTerm': 1L, u'priorityAtElection': 1.0, u'numCatchUpOps': 0L, u'lastElectionReason': u'electionTimeout', u'lastCommittedOpTimeAtElection': {u'ts': Timestamp(0, 0), u't': -1L}, u'lastSeenOpTimeAtElection': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'electionTimeoutMillis': 10000L, u'newTermStartDate': datetime.datetime(2020, 3, 26, 19, 3, 14, 520000)}, u'writableVotingMembersCount': 3, u'syncSourceId': -1, u'votingMembersCount': 3, u'myState': 1, u'lastStableRecoveryTimestamp': Timestamp(1585249394, 3), u'members': [{u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27017', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 14, 933000), u'_id': 0, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 506000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 11, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'name': u'localhost:27018', u'syncSourceHost': u'', u'infoMessage': u'', u'pingMs': 0L, u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 3), u'syncSourceId': -1, u'state': 2, u'health': 1.0, u'optimeDurable': {u'ts': Timestamp(1585249383, 1), u't': -1L}, u'lastHeartbeatMessage': u'', u'stateStr': u'SECONDARY', u'lastHeartbeatRecv': datetime.datetime(2020, 3, 26, 19, 3, 15, 27000), u'_id': 1, u'lastHeartbeat': datetime.datetime(2020, 3, 26, 19, 3, 14, 509000), u'optimeDurableDate': datetime.datetime(2020, 3, 26, 19, 3, 3)}, {u'uptime': 13, u'configVersion': 1, u'optime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'name': u'localhost:27019', u'syncSourceHost': u'', u'infoMessage': u'could not find member to sync from', u'optimeDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'syncSourceId': -1, u'electionTime': Timestamp(1585249394, 1), u'self': True, u'state': 1, u'health': 1.0, u'stateStr': u'PRIMARY', u'lastHeartbeatMessage': u'', u'_id': 2, u'electionDate': datetime.datetime(2020, 3, 26, 19, 3, 14), u'configTerm': 0}], u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'date': datetime.datetime(2020, 3, 26, 19, 3, 15, 133000), u'ok': 1.0, u'operationTime': Timestamp(1585249395, 1), u'writeMajorityCount': 2}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,134 [DEBUG] mongo_orchestration.replica_sets:273 - run_command(serverStatus, None, False, 2)
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,134 [DEBUG] mongo_orchestration.replica_sets:444 - connection(localhost:27019, Primary(), 300)
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,134 [DEBUG] mongo_orchestration.replica_sets:461 - connection to the localhost:27019
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,148 [DEBUG] mongo_orchestration.replica_sets:279 - command result: {u'metrics': {u'commands': {u'updateUser': {u'failed': 0L, u'total': 0L}, u'killAllSessions': {u'failed': 0L, u'total': 0L}, u'dropRole': {u'failed': 0L, u'total': 0L}, u'prepareTransaction': {u'failed': 0L, u'total': 0L}, u'planCacheSetFilter': {u'failed': 0L, u'total': 0L}, u'fsyncUnlock': {u'failed': 0L, u'total': 0L}, u'_configsvrDropDatabase': {u'failed': 0L, u'total': 0L}, u'usersInfo': {u'failed': 0L, u'total': 0L}, u'whatsmysni': {u'failed': 0L, u'total': 0L}, u'replSetStepDownWithForce': {u'failed': 0L, u'total': 0L}, u'makeSnapshot': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkSplit': {u'failed': 0L, u'total': 0L}, u'_configsvrMoveChunk': {u'failed': 0L, u'total': 0L}, u'abortTransaction': {u'failed': 0L, u'total': 0L}, u'_hashBSONElement': {u'failed': 0L, u'total': 0L}, u'find': {u'failed': 0L, u'total': 9L}, u'endSessions': {u'failed': 0L, u'total': 0L}, u'compact': {u'failed': 0L, u'total': 0L}, u'createIndexes': {u'failed': 0L, u'total': 0L}, u'moveChunk': {u'failed': 0L, u'total': 0L}, u'_mergeAuthzCollections': {u'failed': 0L, u'total': 0L}, u'explain': {u'failed': 0L, u'total': 0L}, u'_migrateClone': {u'failed': 0L, u'total': 0L}, u'setDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'checkShardingIndex': {u'failed': 0L, u'total': 0L}, u'<UNKNOWN>': 0L, u'_flushDatabaseCacheUpdates': {u'failed': 0L, u'total': 0L}, u'serverStatus': {u'failed': 0L, u'total': 1L}, u'replSetGetStatus': {u'failed': 0L, u'total': 4L}, u'replSetRequestVotes': {u'failed': 0L, u'total': 0L}, u'getShardMap': {u'failed': 0L, u'total': 0L}, u'grantRolesToUser': {u'failed': 0L, u'total': 0L}, u'dbCheck': {u'failed': 0L, u'total': 0L}, u'_flushRoutingTableCacheUpdates': {u'failed': 0L, u'total': 0L}, u'shardConnPoolStats': {u'failed': 0L, u'total': 0L}, u'findAndModify': {u'failed': 0L, u'total': 0L}, u'splitChunk': {u'failed': 0L, u'total': 0L}, u'planCacheClear': {u'failed': 0L, u'total': 0L}, u'getCmdLineOpts': {u'failed': 0L, u'total': 0L}, u'insert': {u'failed': 0L, u'total': 2L}, u'replSetInitiate': {u'failed': 0L, u'total': 0L}, u'replSetGetConfig': {u'failed': 0L, u'total': 1L}, u'fsync': {u'failed': 0L, u'total': 0L}, u'refreshLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'appendOplogNote': {u'failed': 0L, u'total': 0L}, u'drop': {u'failed': 0L, u'total': 0L}, u'mapreduce': {u'shardedfinish': {u'failed': 0L, u'total': 0L}}, u'_getNextSessionMods': {u'failed': 0L, u'total': 0L}, u'getDefaultRWConcern': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerCollectionStatus': {u'failed': 0L, u'total': 0L}, u'_recvChunkAbort': {u'failed': 0L, u'total': 0L}, u'replSetAbortPrimaryCatchUp': {u'failed': 0L, u'total': 0L}, u'_configsvrRefineCollectionShardKey': {u'failed': 0L, u'total': 0L}, u'captrunc': {u'failed': 0L, u'total': 0L}, u'replSetSyncFrom': {u'failed': 0L, u'total': 0L}, u'_configsvrClearJumboFlag': {u'failed': 0L, u'total': 0L}, u'connectionStatus': {u'failed': 0L, u'total': 0L}, u'applyOps': {u'failed': 0L, u'total': 0L}, u'_recvChunkStatus': {u'failed': 0L, u'total': 0L}, u'replSetGetRBID': {u'failed': 0L, u'total': 1L}, u'setParameter': {u'failed': 0L, u'total': 0L}, u'startRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'dataSize': {u'failed': 0L, u'total': 0L}, u'dbHash': {u'failed': 0L, u'total': 0L}, u'_configsvrEnableSharding': {u'failed': 0L, u'total': 0L}, u'authenticate': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromRole': {u'failed': 0L, u'total': 0L}, u'grantPrivilegesToRole': {u'failed': 0L, u'total': 0L}, u'clearLog': {u'failed': 0L, u'total': 0L}, u'planCacheClearFilters': {u'failed': 0L, u'total': 0L}, u'getParameter': {u'failed': 0L, u'total': 0L}, u'dropIndexes': {u'failed': 0L, u'total': 0L}, u'listDatabases': {u'failed': 0L, u'total': 0L}, u'replSetResizeOplog': {u'failed': 0L, u'total': 0L}, u'collStats': {u'failed': 0L, u'total': 0L}, u'hostInfo': {u'failed': 0L, u'total': 0L}, u'getShardVersion': {u'failed': 0L, u'total': 0L}, u'configureFailPoint': {u'failed': 0L, u'total': 0L}, u'voteCommitIndexBuild': {u'failed': 0L, u'total': 0L}, u'dropDatabase': {u'failed': 0L, u'total': 0L}, u'dropConnections': {u'failed': 0L, u'total': 0L}, u'update': {u'failed': 0L, u'total': 0L}, u'revokePrivilegesFromRole': {u'failed': 0L, u'total': 0L}, u'logout': {u'failed': 0L, u'total': 0L}, u'reapLogicalSessionCacheNow': {u'failed': 0L, u'total': 0L}, u'_transferMods': {u'failed': 0L, u'total': 0L}, u'_configsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'httpClientRequest': {u'failed': 0L, u'total': 0L}, u'isMaster': {u'failed': 0L, u'total': 58L}, u'collMod': {u'failed': 0L, u'total': 0L}, u'replSetReconfig': {u'failed': 0L, u'total': 0L}, u'shardingState': {u'failed': 0L, u'total': 0L}, u'getDatabaseVersion': {u'failed': 0L, u'total': 0L}, u'getLog': {u'failed': 0L, u'total': 0L}, u'listCollections': {u'failed': 0L, u'total': 0L}, u'connPoolSync': {u'failed': 0L, u'total': 0L}, u'flushRouterConfig': {u'failed': 0L, u'total': 0L}, u'replSetMaintenance': {u'failed': 0L, u'total': 0L}, u'top': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateDatabase': {u'failed': 0L, u'total': 0L}, u'replSetStepDown': {u'failed': 0L, u'total': 0L}, u'features': {u'failed': 0L, u'total': 0L}, u'replSetTest': {u'failed': 0L, u'total': 0L}, u'currentOp': {u'failed': 0L, u'total': 0L}, u'connPoolStats': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStop': {u'failed': 0L, u'total': 0L}, u'getFreeMonitoringStatus': {u'failed': 0L, u'total': 0L}, u'echo': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStatus': {u'failed': 0L, u'total': 0L}, u'_shardsvrCloneCatalogData': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShardFromZone': {u'failed': 0L, u'total': 0L}, u'planCacheListFilters': {u'failed': 0L, u'total': 0L}, u'shutdown': {u'failed': 0L, u'total': 0L}, u'refreshSessions': {u'failed': 0L, u'total': 0L}, u'getDiagnosticData': {u'failed': 0L, u'total': 0L}, u'validate': {u'failed': 0L, u'total': 0L}, u'repairDatabase': {u'failed': 0L, u'total': 0L}, u'saslStart': {u'failed': 0L, u'total': 0L}, u'distinct': {u'failed': 0L, u'total': 0L}, u'replSetFreeze': {u'failed': 0L, u'total': 0L}, u'create': {u'failed': 0L, u'total': 0L}, u'splitVector': {u'failed': 0L, u'total': 0L}, u'renameCollection': {u'failed': 0L, u'total': 0L}, u'logRotate': {u'failed': 0L, u'total': 0L}, u'_getUserCacheGeneration': {u'failed': 0L, u'total': 0L}, u'dropAllRolesFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMigration': {u'failed': 0L, u'total': 0L}, u'invalidateUserCache': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitChunkMerge': {u'failed': 0L, u'total': 0L}, u'whatsmyuri': {u'failed': 0L, u'total': 0L}, u'geoSearch': {u'failed': 0L, u'total': 0L}, u'updateRole': {u'failed': 0L, u'total': 0L}, u'_configsvrDropCollection': {u'failed': 0L, u'total': 0L}, u'logApplicationMessage': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShard': {u'failed': 0L, u'total': 0L}, u'waitForFailPoint': {u'failed': 0L, u'total': 0L}, u'killOp': {u'failed': 0L, u'total': 0L}, u'reIndex': {u'failed': 0L, u'total': 0L}, u'_isSelf': {u'failed': 0L, u'total': 2L}, u'stopRecordingTraffic': {u'failed': 0L, u'total': 0L}, u'unsetSharding': {u'failed': 0L, u'total': 0L}, u'getnonce': {u'failed': 0L, u'total': 0L}, u'listIndexes': {u'failed': 1L, u'total': 1L}, u'sleep': {u'failed': 0L, u'total': 0L}, u'_addShard': {u'failed': 0L, u'total': 0L}, u'count': {u'failed': 0L, u'total': 0L}, u'cpuload': {u'failed': 0L, u'total': 0L}, u'filemd5': {u'failed': 0L, u'total': 0L}, u'setShardVersion': {u'failed': 0L, u'total': 0L}, u'internalRenameIfOptionsAndIndexesMatch': {u'failed': 0L, u'total': 0L}, u'commitTransaction': {u'failed': 0L, u'total': 0L}, u'startSession': {u'failed': 0L, u'total': 0L}, u'_configsvrAddShardToZone': {u'failed': 0L, u'total': 0L}, u'_configsvrUpdateZoneKeyRange': {u'failed': 0L, u'total': 0L}, u'delete': {u'failed': 0L, u'total': 0L}, u'getMore': {u'failed': 0L, u'total': 2L}, u'rolesInfo': {u'failed': 0L, u'total': 0L}, u'revokeRolesFromUser': {u'failed': 0L, u'total': 0L}, u'setFeatureCompatibilityVersion': {u'failed': 0L, u'total': 0L}, u'dropUser': {u'failed': 0L, u'total': 0L}, u'_killOperations': {u'failed': 0L, u'total': 0L}, u'saslContinue': {u'failed': 0L, u'total': 0L}, u'emptycapped': {u'failed': 0L, u'total': 0L}, u'_configsvrRemoveShard': {u'failed': 0L, u'total': 0L}, u'_cloneCollectionOptionsFromPrimaryShard': {u'failed': 0L, u'total': 0L}, u'driverOIDTest': {u'failed': 0L, u'total': 0L}, u'getLastError': {u'failed': 0L, u'total': 0L}, u'_configsvrCreateCollection': {u'failed': 0L, u'total': 0L}, u'waitForOngoingChunkSplits': {u'failed': 0L, u'total': 0L}, u'convertToCapped': {u'failed': 0L, u'total': 0L}, u'replSetHeartbeat': {u'failed': 0L, u'total': 49L}, u'ping': {u'failed': 0L, u'total': 0L}, u'availableQueryOptions': {u'failed': 0L, u'total': 0L}, u'dropAllUsersFromDatabase': {u'failed': 0L, u'total': 0L}, u'_configsvrEnsureChunkVersionIsGreaterThan': {u'failed': 0L, u'total': 0L}, u'lockInfo': {u'failed': 0L, u'total': 0L}, u'cloneCollectionAsCapped': {u'failed': 0L, u'total': 0L}, u'godinsert': {u'failed': 0L, u'total': 0L}, u'listCommands': {u'failed': 0L, u'total': 0L}, u'_configsvrBalancerStart': {u'failed': 0L, u'total': 0L}, u'profile': {u'failed': 0L, u'total': 0L}, u'_shardsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'grantRolesToRole': {u'failed': 0L, u'total': 0L}, u'_recvChunkStart': {u'failed': 0L, u'total': 0L}, u'stageDebug': {u'failed': 0L, u'total': 0L}, u'killCursors': {u'failed': 0L, u'total': 0L}, u'coordinateCommitTransaction': {u'failed': 0L, u'total': 0L}, u'mapReduce': {u'failed': 0L, u'total': 0L}, u'_shardsvrMovePrimary': {u'failed': 0L, u'total': 0L}, u'setCommittedSnapshot': {u'failed': 0L, u'total': 0L}, u'createUser': {u'failed': 0L, u'total': 0L}, u'aggregate': {u'failed': 0L, u'total': 0L}, u'_configsvrCommitMovePrimary': {u'failed': 0L, u'total': 0L}, u'replSetUpdatePosition': {u'failed': 0L, u'total': 11L}, u'replSetStepUp': {u'failed': 0L, u'total': 0L}, u'mergeChunks': {u'failed': 0L, u'total': 0L}, u'killAllSessionsByPattern': {u'failed': 0L, u'total': 0L}, u'createRole': {u'failed': 0L, u'total': 0L}, u'_configsvrShardCollection': {u'failed': 0L, u'total': 0L}, u'killSessions': {u'failed': 0L, u'total': 0L}, u'dbStats': {u'failed': 0L, u'total': 0L}, u'_recvChunkCommit': {u'failed': 0L, u'total': 0L}, u'cleanupOrphaned': {u'failed': 0L, u'total': 0L}, u'setIndexCommitQuorum': {u'failed': 0L, u'total': 0L}, u'buildInfo': {u'failed': 0L, u'total': 1L}, u'resetError': {u'failed': 0L, u'total': 0L}}, u'aggStageCounters': {u'$_internalSplitPipeline': 0L, u'$project': 0L, u'$lookup': 0L, u'$replaceWith': 0L, u'$geoNear': 0L, u'$indexStats': 0L, u'$group': 0L, u'$skip': 0L, u'$merge': 0L, u'$set': 0L, u'$out': 0L, u'$sort': 0L, u'$unset': 0L, u'$unwind': 0L, u'$redact': 0L, u'$currentOp': 0L, u'$unionWith': 0L, u'$listSessions': 0L, u'$searchBeta': 0L, u'$sortByCount': 0L, u'$changeStream': 0L, u'$limit': 0L, u'$planCacheStats': 0L, u'$sample': 0L, u'$addFields': 0L, u'$bucketAuto': 0L, u'$listLocalSessions': 0L, u'$_internalInhibitOptimization': 0L, u'$mergeCursors': 0L, u'$facet': 0L, u'$match': 0L, u'$collStats': 0L, u'$count': 0L, u'$_internalSearchIdLookup': 0L, u'$listCachedAndActiveUsers': 0L, u'$backupCursor': 0L, u'$graphLookup': 0L, u'$replaceRoot': 0L, u'$backupCursorExtend': 0L, u'$search': 0L, u'$_internalSearchMongotRemote': 0L, u'$bucket': 0L}, u'getLastError': {u'default': {u'wtimeouts': 0L, u'unsatisfiable': 0L}, u'wtime': {u'num': 2, u'totalMillis': 530}, u'wtimeouts': 0L}, u'queryExecutor': {u'collectionScans': {u'nonTailable': 2L, u'total': 3L}, u'scanned': 0L, u'scannedObjects': 9L}, u'cursor': {u'timedOut': 0L, u'open': {u'pinned': 1L, u'total': 1L, u'noTimeout': 0L}}, u'record': {u'moves': 0L}, u'repl': {u'syncSource': {u'numSelections': 11L, u'numTimesChoseSame': 0L, u'numTimesCouldNotFind': 11L, u'numTimesChoseDifferent': 0L}, u'network': {u'ops': 1L, u'notMasterUnacknowledgedWrites': 0L, u'bytes': 93L, u'notMasterLegacyUnacknowledgedWrites': 0L, u'getmores': {u'numEmptyBatches': 0L, u'num': 1, u'totalMillis': 0}, u'replSetUpdatePosition': {u'num': 0L}, u'readersCreated': 2L, u'oplogGetMoresProcessed': {u'num': 1, u'totalMillis': 0}}, u'initialSync': {u'failures': 0L, u'completed': 1L, u'failedAttempts': 0L}, u'buffer': {u'count': 0L, u'sizeBytes': 0L, u'maxSizeBytes': 268435456L}, u'executor': {u'shuttingDown': False, u'queues': {u'sleepers': 3, u'networkInProgress': 0}, u'unsignaledEvents': 0, u'pool': {u'inProgressCount': 0}, u'networkInterface': u'DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL'}, u'stateTransition': {u'userOperationsKilled': 0L, u'lastStateTransition': u'stepUp', u'userOperationsRunning': 0L}, u'apply': {u'batchSize': 0L, u'batches': {u'num': 0, u'totalMillis': 0}, u'attemptsToBecomeSecondary': 1L, u'ops': 0L}}, u'ttl': {u'passes': 0L, u'deletedDocuments': 0L}, u'query': {u'updateOneOpStyleBroadcastWithExactIDCount': 0L, u'planCacheTotalSizeEstimateBytes': 0L}, u'operation': {u'writeConflicts': 0L, u'scanAndOrder': 1L}, u'document': {u'deleted': 0L, u'updated': 0L, u'inserted': 2L, u'returned': 9L}}, u'process': u'mongod', u'pid': 21556L, u'defaultRWConcern': {u'localUpdateWallClockTime': datetime.datetime(2020, 3, 26, 19, 3, 2, 842000)}, u'connections': {u'available': 51193, u'totalCreated': 26, u'awaitingTopologyChanges': 0, u'current': 7, u'active': 2, u'exhaustIsMaster': 0}, u'locks': {u'Database': {u'acquireCount': {u'r': 108L, u'W': 15L, u'w': 44L}}, u'Global': {u'acquireCount': {u'r': 148L, u'W': 5L, u'w': 63L}}, u'Collection': {u'acquireCount': {u'r': 50L, u'W': 6L, u'w': 36L}}, u'ParallelBatchWriterMode': {u'acquireCount': {u'r': 93L}}, u'Mutex': {u'acquireCount': {u'r': 158L, u'W': 3L}}, u'oplog': {u'acquireCount': {u'r': 66L, u'W': 1L, u'w': 3L}}, u'ReplicationStateTransition': {u'timeAcquiringMicros': {u'W': 2L, u'w': 85L}, u'acquireWaitCount': {u'W': 1L, u'w': 1L}, u'acquireCount': {u'W': 2L, u'w': 216L}}}, u'storageEngine': {u'name': u'wiredTiger', u'supportsTwoPhaseIndexBuild': True, u'persistent': True, u'dropPendingIdents': 0L, u'readOnly': False, u'supportsSnapshotReadConcern': True, u'supportsCheckpointCursors': True, u'backupCursorOpen': False, u'supportsPendingDrops': True, u'supportsCommittedReads': True, u'oldestRequiredTimestampForCrashRecovery': Timestamp(1585249394, 3)}, u'$clusterTime': {u'clusterTime': Timestamp(1585249395, 1), u'signature': {u'keyId': 0L, u'hash': Binary('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0)}}, u'globalLock': {u'totalTime': 13018000L, u'currentQueue': {u'total': 0, u'writers': 0, u'readers': 0}, u'activeClients': {u'total': 0, u'writers': 0, u'readers': 0}}, u'twoPhaseCommitCoordinator': {u'totalAbortedTwoPhaseCommit': 0L, u'totalStartedTwoPhaseCommit': 0L, u'totalCommittedTwoPhaseCommit': 0L, u'totalCreated': 0L, u'currentInSteps': {u'waitingForVotes': 0L, u'deletingCoordinatorDoc': 0L, u'waitingForDecisionAcks': 0L, u'writingParticipantList': 0L, u'writingDecision': 0L}}, u'opReadConcernCounters': {u'available': 0L, u'none': 7L, u'linearizable': 0L, u'majority': 0L, u'snapshot': 0L, u'local': 2L}, u'extra_info': {u'page_faults': 0L, u'voluntary_context_switches': 2287L, u'page_reclaims': 9744L, u'maximum_resident_set_kb': 133560L, u'user_time_us': 1888000L, u'note': u'fields vary by platform', u'involuntary_context_switches': 579L, u'system_time_us': 124000L, u'input_blocks': 0L, u'output_blocks': 2312L}, u'uptime': 13.0, u'network': {u'numSlowDNSOperations': 0L, u'tcpFastOpen': {u'serverSupported': True, u'accepted': 0L, u'kernelSetting': 1L, u'clientSupported': False}, u'compression': {u'zstd': {u'compressor': {u'bytesOut': 32118L, u'bytesIn': 52228L}, u'decompressor': {u'bytesOut': 56757L, u'bytesIn': 32605L}}, u'noop': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'zlib': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}, u'snappy': {u'compressor': {u'bytesOut': 0L, u'bytesIn': 0L}, u'decompressor': {u'bytesOut': 0L, u'bytesIn': 0L}}}, u'physicalBytesIn': 25386L, u'bytesOut': 88431L, u'numRequests': 132L, u'serviceExecutorTaskStats': {u'threadsRunning': 7, u'executor': u'passthrough'}, u'physicalBytesOut': 73625L, u'numSlowSSLOperations': 0L, u'bytesIn': 35147L}, u'uptimeMillis': 13021L, u'transactions': {u'transactionsCollectionWriteCount': 0L, u'retriedCommandsCount': 0L, u'currentOpen': 0L, u'currentPrepared': 0L, u'retriedStatementsCount': 0L, u'totalPreparedThenCommitted': 0L, u'totalPrepared': 0L, u'totalAborted': 0L, u'totalCommitted': 0L, u'currentInactive': 0L, u'currentActive': 0L, u'totalStarted': 0L, u'totalPreparedThenAborted': 0L}, u'operationTime': Timestamp(1585249395, 1), u'trafficRecording': {u'running': False}, u'version': u'4.3.4', u'tcmalloc': {u'generic': {u'current_allocated_bytes': 139884624, u'heap_size': 143835136}, u'tcmalloc': {u'release_rate': 1.0, u'pageheap_unmapped_bytes': 0, u'pageheap_total_commit_bytes': 143835136, u'current_total_thread_cache_bytes': 2208600, u'central_cache_free_bytes': 295896, u'max_total_thread_cache_bytes': 979369984, u'pageheap_total_reserve_bytes': 143835136, u'total_free_bytes': 2959280, u'transfer_cache_free_bytes': 454784, u'pageheap_decommit_count': 0, u'pageheap_reserve_count': 58, u'spinlock_total_delay_ns': 730315, u'pageheap_scavenge_count': 0, u'pageheap_committed_bytes': 143835136, u'pageheap_total_decommit_bytes': 0, u'pageheap_free_bytes': 991232, u'pageheap_commit_count': 58, u'aggressive_memory_decommit': 0, u'formattedString': u'------------------------------------------------\nMALLOC:      139885200 (  133.4 MiB) Bytes in use by application\nMALLOC: +       991232 (    0.9 MiB) Bytes in page heap freelist\nMALLOC: +       295896 (    0.3 MiB) Bytes in central cache freelist\nMALLOC: +       454784 (    0.4 MiB) Bytes in transfer cache freelist\nMALLOC: +      2208024 (    2.1 MiB) Bytes in thread cache freelists\nMALLOC: +      2883584 (    2.8 MiB) Bytes in malloc metadata\nMALLOC:   ------------\nMALLOC: =    146718720 (  139.9 MiB) Actual memory used (physical + swap)\nMALLOC: +            0 (    0.0 MiB) Bytes released to OS (aka unmapped)\nMALLOC:   ------------\nMALLOC: =    146718720 (  139.9 MiB) Virtual address space used\nMALLOC:\nMALLOC:           1256              Spans in use\nMALLOC:             75              Thread heaps in use\nMALLOC:           4096              Tcmalloc page size\n------------------------------------------------\nCall ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).\nBytes released to the OS take up virtual address space but no physical memory.\n', u'thread_cache_free_bytes': 2208600}}, u'electionMetrics': {u'numCatchUpsAlreadyCaughtUp': 1L, u'priorityTakeover': {u'successful': 0L, u'called': 0L}, u'numStepDownsCausedByHigherTerm': 0L, u'stepUpCmd': {u'successful': 0L, u'called': 0L}, u'catchUpTakeover': {u'successful': 0L, u'called': 0L}, u'numCatchUpsSkipped': 0L, u'numCatchUps': 0L, u'numCatchUpsSucceeded': 0L, u'electionTimeout': {u'successful': 1L, u'called': 1L}, u'averageCatchUpOps': 0.0, u'numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd': 0L, u'numCatchUpsTimedOut': 0L, u'numCatchUpsFailedWithNewTerm': 0L, u'numCatchUpsFailedWithError': 0L, u'freezeTimeout': {u'successful': 0L, u'called': 0L}}, u'mem': {u'resident': 130, u'supported': True, u'bits': 64, u'virtual': 1970}, u'opcountersRepl': {u'getmore': 0L, u'insert': 0L, u'update': 0L, u'command': 0L, u'query': 0L, u'delete': 0L}, u'wiredTiger': {u'data-handle': {u'session dhandles swept': 2, u'connection sweeps': 7, u'connection sweep dhandles removed from hash list': 4, u'connection data handles currently active': 58, u'connection data handle size': 432, u'connection sweep dhandles closed': 6, u'session sweep attempts': 79, u'connection sweep candidate became referenced': 0, u'connection sweep time-of-death sets': 50}, u'reconciliation': {u'fast-path pages deleted': 0, u'split objects currently awaiting free': 0, u'split bytes currently awaiting free': 0, u'pages deleted': 4, u'page reconciliation calls for eviction': 1, u'page reconciliation calls': 47}, u'transaction': {u'number of named snapshots dropped': 0, u'set timestamp durable calls': 1, u'read timestamp queue entries walked': 1, u'transaction checkpoint currently running': 0, u'set timestamp stable updates': 4, u'transaction begins': 108, u'transaction fsync calls for checkpoint after allocating the transaction ID': 2, u'query timestamp calls': 43, u'Number of prepared updates added to cache overflow': 0, u'read timestamp queue inserts total': 2, u'read timestamp queue insert to empty': 1, u'durable timestamp queue insert to empty': 6, u'transactions committed': 39, u'transaction checkpoint most recent time (msecs)': 16, u'set timestamp oldest calls': 5, u'transaction checkpoints': 2, u'rollback to stable calls': 0, u'set timestamp stable calls': 4, u'transaction range of IDs currently pinned by a checkpoint': 0, u'transaction range of timestamps currently pinned': 21474836480.0, u'durable timestamp queue inserts total': 7, u'set timestamp durable updates': 1, u'Number of prepared updates': 0, u'transaction sync calls': 0, u'durable timestamp queue entries walked': 1, u'set timestamp oldest updates': 5, u'prepared transactions rolled back': 0, u'update conflicts': 0, u'transaction checkpoint scrub time (msecs)': 0, u'transaction fsync duration for checkpoint after allocating the transaction ID (usecs)': 11118, u'prepared transactions committed': 0, u'read timestamp queue length': 1, u'transaction checkpoint max time (msecs)': 20, u'transaction checkpoints skipped because database was clean': 0, u'transaction checkpoint scrub dirty target': 0, u'rollback to stable updates removed from cache overflow': 0, u'durable timestamp queue inserts to head': 1, u'number of named snapshots created': 0, u'transaction range of timestamps pinned by the oldest timestamp': 21474836480.0, u'transaction range of timestamps pinned by a checkpoint': 6808594307528785921L, u'read timestamp queue inserts to head': 1, u'durable timestamp queue length': 1, u'transaction checkpoint min time (msecs)': 16, u'prepared transactions': 0, u'transaction checkpoint total time (msecs)': 36, u'rollback to stable updates aborted': 0, u'transaction checkpoint generation': 3, u'transaction range of timestamps pinned by the oldest active read timestamp': 0, u'transaction read timestamp of the oldest active reader': 0, u'set timestamp calls': 9, u'prepared transactions currently active': 0, u'transaction range of IDs currently pinned by named snapshots': 0, u'transactions rolled back': 69, u'transaction failures due to cache overflow': 0, u'transaction range of IDs currently pinned': 2}, u'capacity': {u'bytes read': 8192, u'time waiting due to total capacity (usecs)': 0, u'background fsync file handles synced': 0, u'time waiting during read (usecs)': 0, u'bytes written for eviction': 74, u'time waiting during checkpoint (usecs)': 0, u'time waiting during eviction (usecs)': 0, u'bytes written total': 123351, u'bytes written for checkpoint': 68493, u'background fsync file handles considered': 0, u'time waiting during logging (usecs)': 0, u'bytes written for log': 54784, u'background fsync time (msecs)': 0, u'threshold to call fsync': 0}, u'log': {u'slot join calls yielded': 0, u'log sync_dir operations': 1, u'log sync operations': 44, u'log write operations': 161, u'log server thread advances write LSN': 6, u'slot unbuffered writes': 0, u'maximum log file size': 104857600, u'log scan records requiring two reads': 0, u'slot transitions unable to find free slot': 0, u'records processed by log scan': 0, u'total log buffer size': 33554432, u'slot close unbuffered waits': 0, u'log records too small to compress': 68, u'log force write operations skipped': 143, u'log scan operations': 0, u'pre-allocated log files used': 0, u'pre-allocated log files not ready and missed': 1, u'total size of compressed records': 26809, u'pre-allocated log files prepared': 2, u'log sync time duration (usecs)': 34827, u'total in-memory size of compressed records': 61955, u'yields waiting for previous log file close': 0, u'slot close lost race': 0, u'log records not compressed': 59, u'slot join calls did not yield': 161, u'log force write operations': 149, u'slot join calls slept': 0, u'written slots coalesced': 0, u'slot join atomic update races': 0, u'slot join calls found active slot closed': 0, u'log records compressed': 34, u'number of pre-allocated log files to create': 2, u'log bytes written': 54656, u'slot join calls atomic updates raced': 0, u'busy returns attempting to switch slots': 0, u'log files manually zero-filled': 0, u'log bytes of payload data': 40070, u'log flush operations': 128, u'log sync_dir time duration (usecs)': 0, u'force archive time sleeping (usecs)': 0, u'slot closures': 43, u'log server thread write LSN walk skipped': 1013, u'log release advances write LSN': 37, u'slot joins yield time (usecs)': 0, u'slot join found active slot closed': 0, u'logging bytes consolidated': 54144}, u'lock': {u'durable timestamp queue write lock acquisitions': 7, u'table lock internal thread time waiting for the table lock (usecs)': 0, u'dhandle read lock acquisitions': 122, u'checkpoint lock application thread wait time (usecs)': 0, u'metadata lock application thread wait time (usecs)': 0, u'dhandle lock application thread time waiting (usecs)': 0, u'metadata lock acquisitions': 2, u'table lock application thread time waiting for the table lock (usecs)': 2991, u'dhandle write lock acquisitions': 72, u'durable timestamp queue lock application thread time waiting (usecs)': 0, u'read timestamp queue write lock acquisitions': 2, u'read timestamp queue lock internal thread time waiting (usecs)': 0, u'metadata lock internal thread wait time (usecs)': 0, u'read timestamp queue lock application thread time waiting (usecs)': 0, u'txn global write lock acquisitions': 30, u'checkpoint lock acquisitions': 2, u'table write lock acquisitions': 60, u'txn global read lock acquisitions': 67, u'table read lock acquisitions': 0, u'schema lock application thread wait time (usecs)': 0, u'checkpoint lock internal thread wait time (usecs)': 0, u'schema lock acquisitions': 41, u'txn global lock internal thread time waiting (usecs)': 0, u'dhandle lock internal thread time waiting (usecs)': 0, u'txn global lock application thread time waiting (usecs)': 0, u'read timestamp queue read lock acquisitions': 0, u'durable timestamp queue read lock acquisitions': 0, u'schema lock internal thread wait time (usecs)': 0, u'durable timestamp queue lock internal thread time waiting (usecs)': 0}, u'cache': {u'eviction server evicting pages': 0, u'pages seen by eviction walk that are already queued': 0, u'tracked dirty pages in the cache': 7, u'eviction walk target strategy both clean and dirty pages': 0, u'cache overflow cursor application thread wait time (usecs)': 0, u'hazard pointer check entries walked': 0, u'page split during eviction deepened the tree': 0, u'pages walked for eviction': 0, u'tracked dirty bytes in the cache': 91816, u'internal pages queued for eviction': 0, u'eviction worker thread stable number': 0, u'eviction walks started from saved location in tree': 0, u'checkpoint blocked page eviction': 0, u'tracked bytes belonging to internal pages in the cache': 9553, u'page written requiring cache overflow records': 0, u'pages queued for urgent eviction': 0, u'overflow pages read into cache': 0, u'pages written from cache': 44, u'eviction walk target pages histogram - 0-9': 0, u'pages selected for eviction unable to be evicted because of failure in reconciliation': 0, u'hazard pointer blocked page eviction': 0, u'cache overflow table insert calls': 0, u'eviction walk target strategy only clean pages': 0, u'files with new eviction walks started': 0, u'in-memory page splits': 0, u'unmodified pages evicted': 0, u'maximum bytes configured': 3383754752.0, u'modified pages evicted': 2, u'eviction server unable to reach eviction goal': 0, u'forced eviction - pages evicted that were clean time (usecs)': 0, u'pages read into cache requiring cache overflow for checkpoint': 0, u'pages read into cache after truncate in prepare state': 0, u'internal pages split during eviction': 0, u'application threads page write from cache to disk time (usecs)': 863, u'eviction walks gave up because they saw too many pages and found no candidates': 0, u'forced eviction - pages selected unable to be evicted time': 0, u'percentage overhead': 8, u'pages evicted by application threads': 0, u'eviction walk target strategy only dirty pages': 0, u'forced eviction - pages selected because of too many deleted items count': 0, u'forced eviction - pages evicted that were dirty count': 0, u'eviction walks reached end of tree': 0, u'application threads page read from disk to cache time (usecs)': 2, u'eviction currently operating in aggressive mode': 0, u'in-memory page passed criteria to be split': 0, u'eviction state': 128, u'force re-tuning of eviction workers once in a while': 0, u'eviction calls to get a page': 2, u'pages seen by eviction walk': 0, u'pages read into cache with skipped cache overflow entries needed later': 0, u'bytes not belonging to page images in the cache': 116065, u'pages selected for eviction unable to be evicted because of active children on an internal page': 0, u'eviction walk target pages histogram - 128 and higher': 0, u'pages read into cache': 2, u'eviction walks gave up because they restarted their walk twice': 0, u'pages written requiring in-memory restoration': 0, u'eviction worker thread active': 4, u'pages requested from the cache': 993, u'eviction server candidate queue not empty when topping up': 0, u'bytes belonging to page images in the cache': 135, u'internal pages evicted': 0, u'eviction calls to get a page found queue empty after locking': 0, u'forced eviction - pages selected unable to be evicted count': 0, u'internal pages seen by eviction walk that are already queued': 0, u'maximum page size at eviction': 0, u'bytes belonging to the cache overflow table in the cache': 182, u'eviction server candidate queue empty when topping up': 0, u'eviction empty score': 0, u'eviction server slept, because we did not make progress with eviction': 0, u'eviction walks abandoned': 0, u'pages read into cache after truncate': 21, u'application threads page read from disk to cache count': 1, u'bytes currently in the cache': 116200, u'pages selected for eviction unable to be evicted': 0, u'hazard pointer maximum array length': 0, u'operations timed out waiting for space in cache': 0, u'eviction walks started from root of tree': 0, u'tracked bytes belonging to leaf pages in the cache': 106647, u'modified pages evicted by application threads': 0, u'pages queued for eviction': 0, u'pages read into cache requiring cache overflow entries': 0, u'eviction worker thread removed': 0, u'forced eviction - pages selected count': 0, u'files with active eviction walks': 0, u'forced eviction - pages evicted that were clean count': 0, u'cache overflow table on-disk size': 0, u'eviction worker thread created': 0, u'pages selected for eviction unable to be evicted due to newer modifications on a clean page': 0, u'pages currently held in the cache': 43, u'hazard pointer check calls': 0, u'internal pages seen by eviction walk': 0, u'eviction walk target pages histogram - 32-63': 0, u'cache overflow table max on-disk size': 0, u'bytes dirty in the cache cumulative': 36138, u'application threads page write from cache to disk count': 44, u'eviction calls to get a page found queue empty': 2, u'eviction walks gave up because they saw too many pages and found too few candidates': 0, u'bytes written from cache': 69689, u'pages read into cache skipping older cache overflow entries': 0, u'cache overflow score': 0, u'pages queued for urgent eviction during walk': 0, u'forced eviction - pages evicted that were dirty time (usecs)': 0, u'pages read into cache with skipped cache overflow entries needed later by checkpoint': 0, u'eviction worker thread evicting pages': 0, u'bytes read into cache': 125, u'eviction server waiting for a leaf page': 5, u'cache overflow cursor internal thread wait time (usecs)': 0, u'eviction walk target pages histogram - 10-31': 0, u'pages selected for eviction unable to be evicted as the parent page has overflow items': 0, u'eviction passes of a file': 0, u'leaf pages split during eviction': 0, u'pages queued for eviction post lru sorting': 0, u'cache overflow table remove calls': 0, u'cache overflow table entries': 0, u'eviction walk target pages histogram - 64-128': 0}, u'uri': u'statistics:', u'snapshot-window-settings': {u'target available snapshots window size in seconds': 5, u'latest majority snapshot timestamp available': u'Mar 26 19:03:15:1', u'total number of SnapshotTooOld errors': 0L, u'oldest majority snapshot timestamp available': u'Mar 26 19:03:10:1', u'current available snapshots window size in seconds': 5, u'cache pressure percentage threshold': 95, u'max target available snapshots window size in seconds': 5, u'current cache pressure percentage': 0L}, u'cursor': {u'cursor truncate calls': 0, u'cursor update key and value bytes': 0, u'cached cursor count': 53, u'cursor sweeps': 3, u'cursor update value size change': 0, u'cursor search calls': 741, u'cursor next calls': 84, u'cursor modify calls': 3, u'cursor sweep cursors examined': 4, u'cursor reserve calls': 0, u'cursor sweep cursors closed': 0, u'open cursor count': 28, u'cursor search near calls': 25, u'cursor sweep buckets': 18, u'cursor remove calls': 20, u'cursors reused from cache': 59, u'cursor update calls': 0, u'cursor insert key and value bytes': 83056, u'cursor insert calls': 185, u'cursor reset calls': 1114, u'cursor bulk loaded cursor insert calls': 1, u'cursor modify value bytes modified': 24, u'cursor prev calls': 25, u'cursor operation restarted': 0, u'cursor modify key and value bytes affected': 213, u'cursor remove key bytes removed': 710, u'cursor close calls that result in cache': 112, u'cursor create calls': 241}, u'connection': {u'total read I/Os': 45, u'memory re-allocations': 1011, u'pthread mutex shared lock write-lock calls': 276, u'auto adjusting condition resets': 65, u'detected system time went backwards': 0, u'pthread mutex condition wait calls': 299, u'memory frees': 10382, u'pthread mutex shared lock read-lock calls': 1620, u'total fsync I/Os': 117, u'files currently open': 26, u'memory allocations': 12477, u'auto adjusting condition wait calls': 160, u'total write I/Os': 169}, u'session': {u'table import failed calls': 0, u'table compact failed calls': 0, u'table create successful calls': 27, u'table rebalance successful calls': 0, u'table alter successful calls': 0, u'session query timestamp calls': 0, u'table rebalance failed calls': 0, u'table salvage failed calls': 0, u'table truncate failed calls': 0, u'table rename successful calls': 0, u'table verify successful calls': 0, u'table drop failed calls': 0, u'open session count': 22, u'table verify failed calls': 0, u'table alter failed calls': 0, u'table import successful calls': 0, u'table compact successful calls': 0, u'table drop successful calls': 6, u'table alter unchanged and skipped': 0, u'table salvage successful calls': 0, u'table truncate successful calls': 0, u'table create failed calls': 0, u'table rename failed calls': 0}, u'block-manager': {u'bytes read': 28672, u'blocks read': 7, u'blocks pre-loaded': 1, u'bytes written': 417792, u'mapped bytes read': 0, u'bytes written for checkpoint': 413696, u'blocks written': 90, u'mapped blocks read': 0}, u'thread-yield': {u'page acquire busy blocked': 0, u'page acquire time sleeping (usecs)': 0, u'data handle lock yielded': 0, u'connection close blocked waiting for transaction state stabilization': 0, u'connection close yielded for lsm manager shutdown': 0, u'application thread time evicting (usecs)': 0, u'page delete rollback time sleeping for state change (usecs)': 0, u'get reference for page index and slot time sleeping (usecs)': 0, u'page acquire read blocked': 0, u'log server sync yielded for log write': 0, u'page acquire locked blocked': 0, u'page reconciliation yielded due to child modification': 0, u'page acquire eviction blocked': 0, u'application thread time waiting for cache (usecs)': 0, u'page access yielded due to prepare state change': 0}, u'async': {u'total insert calls': 0, u'total remove calls': 0, u'number of operation slots viewed for allocation': 0, u'total allocations': 0, u'current work queue length': 0, u'number of flush calls': 0, u'maximum work queue length': 0, u'total compact calls': 0, u'total update calls': 0, u'number of allocation state races': 0, u'number of times operation allocation failed': 0, u'number of times worker found no work': 0, u'total search calls': 0}, u'concurrentTransactions': {u'write': {u'available': 128, u'totalTickets': 128, u'out': 0}, u'read': {u'available': 127, u'totalTickets': 128, u'out': 1}}, u'thread-state': {u'active filesystem write calls': 0, u'active filesystem read calls': 0, u'active filesystem fsync calls': 0}, u'perf': {u'file system write latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 4) - 1000-9999us': 0, u'operation read latency histogram (bucket 1) - 100-249us': 0, u'file system read latency histogram (bucket 4) - 250-499ms': 0, u'operation write latency histogram (bucket 4) - 1000-9999us': 0, u'file system write latency histogram (bucket 3) - 100-249ms': 0, u'file system read latency histogram (bucket 3) - 100-249ms': 0, u'operation write latency histogram (bucket 1) - 100-249us': 0, u'file system write latency histogram (bucket 2) - 50-99ms': 0, u'file system read latency histogram (bucket 5) - 500-999ms': 0, u'operation read latency histogram (bucket 3) - 500-999us': 0, u'operation write latency histogram (bucket 5) - 10000us+': 0, u'operation read latency histogram (bucket 2) - 250-499us': 0, u'operation write latency histogram (bucket 3) - 500-999us': 0, u'operation read latency histogram (bucket 5) - 10000us+': 0, u'operation write latency histogram (bucket 2) - 250-499us': 0, u'file system read latency histogram (bucket 6) - 1000ms+': 0, u'file system write latency histogram (bucket 1) - 10-49ms': 0, u'file system read latency histogram (bucket 1) - 10-49ms': 0, u'file system write latency histogram (bucket 4) - 250-499ms': 0, u'file system read latency histogram (bucket 2) - 50-99ms': 0}}, u'opLatencies': {u'commands': {u'latency': 5904L, u'ops': 127L}, u'reads': {u'latency': 827L, u'ops': 3L}, u'writes': {u'latency': 0L, u'ops': 0L}, u'transactions': {u'latency': 0L, u'ops': 0L}}, u'uptimeEstimate': 13L, u'host': u'ip-10-122-0-207:27019', u'repl': {u'me': u'localhost:27019', u'ismaster': True, u'setName': u'repl0', u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc66707215b296ea7c40'), u'counter': 5L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'electionId': ObjectId('7fffffff0000000000000001'), u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'majorityWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'opTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'majorityOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}}, u'setVersion': 1, u'secondary': False}, u'encryptionAtRest': {u'encryptionEnabled': False}, u'localTime': datetime.datetime(2020, 3, 26, 19, 3, 15, 146000), u'opcounters': {u'getmore': 2L, u'insert': 2L, u'update': 0L, u'command': 129L, u'query': 9L, u'delete': 0L}, u'oplogTruncation': {u'truncateCount': 0L, u'totalTimeTruncatingMicros': 0L, u'processingMethod': u'scanning', u'totalTimeProcessingMicros': 23L}, u'ok': 1.0, u'logicalSessionRecordCache': {u'lastTransactionReaperJobDurationMillis': 0, u'sessionCatalogSize': 0, u'lastTransactionReaperJobEntriesCleanedUp': 0, u'transactionReaperJobCount': 1, u'lastSessionsCollectionJobDurationMillis': 1, u'sessionsCollectionJobCount': 1, u'lastSessionsCollectionJobEntriesEnded': 0, u'lastSessionsCollectionJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 2, 886000), u'lastTransactionReaperJobTimestamp': datetime.datetime(2020, 3, 26, 19, 3, 2, 886000), u'lastSessionsCollectionJobEntriesRefreshed': 0, u'activeSessionsCount': 0, u'lastSessionsCollectionJobCursorsClosed': 0}, u'flowControl': {u'isLaggedTimeMicros': 0L, u'timeAcquiringMicros': 37L, u'locksPerKiloOp': 0.0, u'enabled': True, u'isLagged': False, u'sustainerRate': 0, u'targetRateLimit': 1000000000, u'isLaggedCount': 0}, u'asserts': {u'msg': 0, u'rollovers': 0, u'regular': 0, u'warning': 0, u'user': 22}, u'transportSecurity': {u'unknown': 0L, u'1.0': 0L, u'1.1': 0L, u'1.2': 33L, u'1.3': 0L}, u'security': {u'authentication': {u'mechanisms': {u'SCRAM-SHA-256': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'SCRAM-SHA-1': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}, u'MONGODB-X509': {u'speculativeAuthenticate': {u'successful': 0L, u'received': 0L}, u'authenticate': {u'successful': 0L, u'received': 0L}}}}, u'SSLServerSubjectName': u'C=US,ST=New York,L=New York City,O=MongoDB,OU=Drivers,CN=localhost', u'SSLServerHasCertificateAuthority': True, u'SSLServerCertificateExpirationDate': datetime.datetime(2039, 5, 22, 22, 32, 56)}}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,148 [DEBUG] mongo_orchestration.replica_sets:375 - member 2 repl info: {u'me': u'localhost:27019', u'ismaster': True, u'setName': u'repl0', u'primary': u'localhost:27019', u'topologyVersion': {u'processId': ObjectId('5e7cfc66707215b296ea7c40'), u'counter': 5L}, u'hosts': [u'localhost:27017', u'localhost:27018', u'localhost:27019'], u'electionId': ObjectId('7fffffff0000000000000001'), u'rbid': 1, u'lastWrite': {u'lastWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'majorityWriteDate': datetime.datetime(2020, 3, 26, 19, 3, 15), u'opTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}, u'majorityOpTime': {u'ts': Timestamp(1585249395, 1), u't': 1L}}, u'setVersion': 1, u'secondary': False}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,148 [DEBUG] mongo_orchestration.replica_sets:599 - real_member_info(2): {'server_id': '109a0265-cabc-447b-bcf6-b64b4e222a5d', 'procInfo': {'pid': 21556, 'optfile': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongo-aofXMz', 'params': {'verbose': 'v', 'replSet': u'repl0', 'networkMessageCompressors': 'zstd,zlib,snappy,noop', u'journal': True, 'logappend': True, 'logpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ/mongod.log', 'enableMajorityReadConcern': True, u'port': 27019, u'sslOnNormalPorts': True, 'oplogSize': 100, 'bind_ip': u'127.0.0.1,::1', u'sslWeakCertificateValidation': True, u'ipv6': True, 'setParameter': {'enableTestCommands': 1, 'maxTransactionLockRequestTimeoutMillis': 25, 'transactionLifetimeLimitSeconds': 3}, u'sslCAFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/ca.pem', u'sslPEMKeyFile': u'/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/x509gen/server.pem', 'dbpath': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/db/mongod-fruaMQ'}, 'name': '/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/mongodb/bin/mongod', 'alive': True}, 'mongodb_uri': 'mongodb://localhost:27019', '_id': 2, 'mongodb_auth_uri': u'mongodb://bob:pwd123@localhost:27019/?authSource=admin', 'statuses': {'primary': True, 'mongos': False}, 'rsInfo': {'primary': True, 'secondary': False}}
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,148 [DEBUG] mongo_orchestration.replica_sets:444 - connection(None, Primary(), 300)
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,212 [INFO] mongo_orchestration.servers:402 - Attempting to connect to localhost:27017
 [2020/03/26 19:03:17.140] 2020-03-26 19:03:15,225 [ERROR] mongo_orchestration.servers:216 - Could not authenticate to localhost:27017 with {'password': u'pwd123', 'name': u'bob'}
 [2020/03/26 19:03:17.140] Traceback (most recent call last):
 [2020/03/26 19:03:17.140]   File "/data/mci/b98bc05df3900812fa0a1451df7890e6/drivers-tools/.evergreen/orchestration/venv/local/lib/python2.7/site-packages/mongo_orchestration/servers.py", line 213, in connection
 [2020/03/26 19:03:17.140]     db.authenticate(**auth_dict)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/database.py", line 1075, in authenticate
 [2020/03/26 19:03:17.140]     connect=True)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/mongo_client.py", line 547, in _cache_credentials
 [2020/03/26 19:03:17.140]     sock_info.authenticate(credentials)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/pool.py", line 581, in authenticate
 [2020/03/26 19:03:17.140]     auth.authenticate(credentials, self)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/auth.py", line 486, in authenticate
 [2020/03/26 19:03:17.140]     auth_func(credentials, sock_info)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/auth.py", line 466, in _authenticate_default
 [2020/03/26 19:03:17.140]     return _authenticate_scram_sha1(credentials, sock_info)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/auth.py", line 209, in _authenticate_scram_sha1
 [2020/03/26 19:03:17.140]     res = sock_info.command(source, cmd)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/pool.py", line 477, in command
 [2020/03/26 19:03:17.140]     collation=collation)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/network.py", line 116, in command
 [2020/03/26 19:03:17.140]     parse_write_concern_error=parse_write_concern_error)
 [2020/03/26 19:03:17.140]   File "/usr/local/lib/python2.7/dist-packages/pymongo/helpers.py", line 210, in _check_command_response
 [2020/03/26 19:03:17.140]     raise OperationFailure(msg % errmsg, code, response)
 [2020/03/26 19:03:17.140] OperationFailure: Authentication failed.
```