### PR TITLE
PYTHON-2470 Upgrade from pymongo 3.5.1 to 3.X latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     license="http://www.apache.org/licenses/LICENSE-2.0.html",
     platforms=['any'],
     url='https://github.com/10gen/mongo-orchestration',
-    install_requires=['pymongo>=3.0.2,<3.6.0',
+    install_requires=['pymongo>=3.0.2,<4',
                       'bottle>=0.12.7',
                       'CherryPy>=3.5.0,<9.0.0'] + extra_deps,
     extras_require={


### PR DESCRIPTION
So far, it looks like this is safe to do. I haven't seen any `KeyNotFound` errors yet: https://evergreen.mongodb.com/version/5fd94da67742ae79ba76f424

Fixes https://github.com/10gen/mongo-orchestration/issues/235