### PR TITLE
PYTHON-2589 Fix slaveDelay -> secondaryDelaySecs name upgrade

### DIFF
--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -596,7 +596,7 @@ class ReplicaSet(BaseModel):
             member_hostname = self._servers.hostname(info['server_id'])
             real_member_info["host"] = member_hostname.lower()
             real_member_info.update(info['rsInfo'])
-            # Fixup slaveDelay->secondaryDelaySecs upgrade
+            # Rename slaveDelay->secondaryDelaySecs to match SERVER-52349.
             if 'secondaryDelaySecs' in cfg_member_info:
                 cfg_member_info.pop('slaveDelay', None)
                 real_member_info['secondaryDelaySecs'] = real_member_info.pop('slaveDelay', None)

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -373,7 +373,7 @@ class ReplicaSet(BaseModel):
                     return result
             repl = self.run_command('serverStatus', arg=None, is_eval=False, member_id=member_id)['repl']
             logger.debug("member {member_id} repl info: {repl}".format(**locals()))
-            for key in ('votes', 'tags', 'arbiterOnly', 'buildIndexes', 'hidden', 'priority', 'slaveDelay', 'votes', 'secondary'):
+            for key in ('votes', 'tags', 'arbiterOnly', 'buildIndexes', 'hidden', 'priority', 'slaveDelay', 'secondaryDelaySecs', 'secondary'):
                 if key in repl:
                     result['rsInfo'][key] = repl[key]
             result['rsInfo']['primary'] = repl.get('ismaster', False)
@@ -596,6 +596,10 @@ class ReplicaSet(BaseModel):
             member_hostname = self._servers.hostname(info['server_id'])
             real_member_info["host"] = member_hostname.lower()
             real_member_info.update(info['rsInfo'])
+            # Fixup slaveDelay->secondaryDelaySecs upgrade
+            if 'secondaryDelaySecs' in cfg_member_info:
+                cfg_member_info.pop('slaveDelay', None)
+                real_member_info['secondaryDelaySecs'] = real_member_info.pop('slaveDelay', None)
             logger.debug("real_member_info({member_id}): {info}".format(member_id=member['_id'], info=info))
             for key in cfg_member_info:
                 if cfg_member_info[key] != real_member_info.get(key, None):


### PR DESCRIPTION
Tested locally where I could reproduce the issue. The problem was caused by SERVER-52349 where the server changed to start reporting slaveDelay as secondaryDelaySecs in replSetGetConfig. This confused MO's repl set config algorithm which waits for a replica set reconfig change to be applied. The fix is to apply the slaveDelay -> secondaryDelaySecs rename client side before comparing the 2 config objects.