### PR TITLE
Expose TLS and authentication options in mongodb_uri field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,11 @@ Run a single test example for debugging with verbose and immediate stdout output
 Changelog
 ---------
 
+Changes in Version 0.8.0 (TBD)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Expose TLS and authentication options in `mongodb_uri` field (#287).
+
 Changes in Version 0.7.0 (2021-04-06)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -85,12 +85,12 @@ class BaseModel(object):
         return params
 
     def mongodb_uri(self, hosts, uri_opts):
-        """Append URI options for auth, TLS, etc."""
-        """Append TLS options"""
+        """Returns the connection string for the cluster"""
+        # Append TLS options
         if self.ssl_params:
             ssl_params = self.ssl_params
             ssl_params.update(DEFAULT_SSL_OPTIONS)
-            """Rewrite ssl* option names to tls*"""
+            # Rewrite ssl* option names to tls*
             for sslKey, tlsKey in SSL_TO_TLS_OPTION_MAPPINGS.items():
                 sslValue = ssl_params.pop(sslKey)
                 if sslValue:
@@ -98,7 +98,7 @@ class BaseModel(object):
                         sslValue = json.dumps(sslValue)
                     uri_opts.append(tlsKey + '=' + sslValue)
 
-        """Append Auth options"""
+        # Append Auth options
         auth_opts = []
         if self.login:
             auth_opts.append(self.login)

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -80,20 +80,32 @@ class BaseModel(object):
         params.pop("clusterAuthMode", None)
         return params
 
-    def mongodb_auth_uri(self, hosts):
-        """Get a connection string with all info necessary to authenticate."""
-        parts = ['mongodb://']
-        if self.login:
-            parts.append(self.login)
-            if self.password:
-                parts.append(':' + self.password)
-            parts.append('@')
-        parts.append(hosts + '/')
-        if self.login:
-            parts.append('?authSource=' + self.auth_source)
-            if self.x509_extra_user:
-                parts.append('&authMechanism=MONGODB-X509')
+    def mongodb_uri(self, hosts, uri_opts):
+        """Get a connection string"""
+        parts = ['mongodb://', hosts, '/']
+
+        """Append URI options for auth, TLS, etc."""
+        """@todo Auth options"""
+        """@todo TLS options"""
+
+        if len(uri_opts) > 0:
+            parts.append('?' + '&'.join(uri_opts))
+
         return ''.join(parts)
+
+    def mongodb_auth_uri(self, hosts, uri_opts):
+        """Get a connection string with all info necessary to authenticate."""
+        auth = []
+        if self.login:
+            auth.append(self.login)
+            if self.password:
+                auth.append(':' + self.password)
+            auth.append('@')
+            uri_opts.append('authSource=' + self.auth_source)
+            if self.x509_extra_user:
+                uri_opts.append('authMechanism=MONGODB-X509')
+
+        return self.mongodb_uri(''.join(auth) + hosts, uri_opts)
 
     def _get_server_version(self, client):
         return tuple(client.admin.command('buildinfo')['versionArray'])

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -20,7 +20,13 @@ import json
 import os
 import ssl
 import stat
+import sys
 import tempfile
+
+if sys.version_info[0] == 2:
+    from urllib import quote_plus
+else:
+    from urllib.parse import quote_plus
 
 WORK_DIR = os.environ.get('MONGO_ORCHESTRATION_HOME', os.getcwd())
 PID_FILE = os.path.join(WORK_DIR, 'server.pid')
@@ -96,7 +102,7 @@ class BaseModel(object):
                 if sslValue:
                     if isinstance(sslValue, bool):
                         sslValue = json.dumps(sslValue)
-                    uri_opts.append(tlsKey + '=' + sslValue)
+                    uri_opts.append(tlsKey + '=' + quote_plus(sslValue))
 
         # Append Auth options
         auth_opts = []

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -94,7 +94,7 @@ class BaseModel(object):
         """Returns the connection string for the cluster"""
         # Append TLS options
         if self.ssl_params:
-            ssl_params = self.ssl_params
+            ssl_params = self.ssl_params.copy()
             ssl_params.update(DEFAULT_SSL_OPTIONS)
             # Rewrite ssl* option names to tls*
             for sslKey, tlsKey in SSL_TO_TLS_OPTION_MAPPINGS.items():

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -57,12 +57,12 @@ class ReplicaSet(BaseModel):
         self.repl_id = rs_params.get('id', None) or str(uuid4())
         self._version = rs_params.get('version')
 
-        self.sslParams = rs_params.get('sslParams', {})
+        self.ssl_params = rs_params.get('sslParams', {})
         self.kwargs = {}
         self.restart_required = self.login or self.auth_key
         self.x509_extra_user = False
 
-        if self.sslParams:
+        if self.ssl_params:
             self.kwargs.update(DEFAULT_SSL_OPTIONS)
 
         members = rs_params.get('members', [])
@@ -310,7 +310,7 @@ class ReplicaSet(BaseModel):
         server_id = self._servers.create(
             name='mongod',
             procParams=proc_params,
-            sslParams=self.sslParams,
+            sslParams=self.ssl_params,
             version=version,
             server_id=server_id
         )

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -237,7 +237,7 @@ class ReplicaSet(BaseModel):
                   "mongodb_uri": mongodb_uri,
                   "orchestration": 'replica_sets'}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(hosts, uri_opts)
+            result['mongodb_auth_uri'] = result['mongodb_uri']
         return result
 
     def repl_member_add(self, params):
@@ -357,8 +357,7 @@ class ReplicaSet(BaseModel):
                   'procInfo': server_info['procInfo'],
                   'statuses': server_info['statuses']}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(
-                self._servers.hostname(server_id))
+            result['mongodb_auth_uri'] = result['mongodb_uri']
         result['rsInfo'] = {}
         if server_info['procInfo']['alive']:
             # Can't call serverStatus on arbiter when running with auth enabled.

--- a/mongo_orchestration/replica_sets.py
+++ b/mongo_orchestration/replica_sets.py
@@ -229,17 +229,15 @@ class ReplicaSet(BaseModel):
     def info(self):
         """return information about replica set"""
         hosts = ','.join(x['host'] for x in self.members())
-        mongodb_uri = 'mongodb://' + hosts + '/?replicaSet=' + self.repl_id
+        uri_opts = ['replicaSet=' + self.repl_id]
+        mongodb_uri = self.mongodb_uri(hosts, uri_opts)
         result = {"id": self.repl_id,
                   "auth_key": self.auth_key,
                   "members": self.members(),
                   "mongodb_uri": mongodb_uri,
                   "orchestration": 'replica_sets'}
         if self.login:
-            # Add replicaSet URI parameter.
-            uri = ('%s&replicaSet=%s'
-                   % (self.mongodb_auth_uri(hosts), self.repl_id))
-            result['mongodb_auth_uri'] = uri
+            result['mongodb_auth_uri'] = self.mongodb_auth_uri(hosts, uri_opts)
         return result
 
     def repl_member_add(self, params):

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -311,7 +311,7 @@ class Server(BaseModel):
                   "serverInfo": server_info, "procInfo": proc_info,
                   "orchestration": 'servers'}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(self.hostname, [])
+            result['mongodb_auth_uri'] = mongodb_uri
         logger.debug("return {result}".format(result=result))
         return result
 

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -300,7 +300,7 @@ class Server(BaseModel):
                 c = self.connection
                 server_info = c.server_info()
                 logger.debug("server_info: {server_info}".format(**locals()))
-                mongodb_uri = 'mongodb://' + self.hostname
+                mongodb_uri = self.mongodb_uri(self.hostname, [])
                 status_info = {"primary": c.is_primary, "mongos": c.is_mongos}
                 logger.debug("status_info: {status_info}".format(**locals()))
             except (pymongo.errors.AutoReconnect, pymongo.errors.OperationFailure, pymongo.errors.ConnectionFailure):
@@ -311,7 +311,7 @@ class Server(BaseModel):
                   "serverInfo": server_info, "procInfo": proc_info,
                   "orchestration": 'servers'}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(self.hostname)
+            result['mongodb_auth_uri'] = self.mongodb_auth_uri(self.hostname, [])
         logger.debug("return {result}".format(result=result))
         return result
 

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -441,7 +441,7 @@ class ShardedCluster(BaseModel):
                   'mongodb_uri': mongodb_uri,
                   'orchestration': 'sharded_clusters'}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(hosts, [])
+            result['mongodb_auth_uri'] = mongodb_uri
         return result
 
     def cleanup(self):

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -50,12 +50,12 @@ class ShardedCluster(BaseModel):
         self._shards = {}
         self.tags = {}
 
-        self.sslParams = params.get('sslParams', {})
+        self.ssl_params = params.get('sslParams', {})
         self.kwargs = {}
         self.restart_required = self.login or self.auth_key
         self.x509_extra_user = False
 
-        if self.sslParams:
+        if self.ssl_params:
             self.kwargs.update(DEFAULT_SSL_OPTIONS)
 
         self.enable_ipv6 = common.ipv6_enabled_sharded(params)
@@ -172,7 +172,7 @@ class ShardedCluster(BaseModel):
             def restart_with_auth(server_or_rs):
                 server_or_rs.x509_extra_user = self.x509_extra_user
                 server_or_rs.auth_source = self.auth_source
-                server_or_rs.ssl_params = self.sslParams
+                server_or_rs.ssl_params = self.ssl_params
                 server_or_rs.login = self.login
                 server_or_rs.password = self.password
                 server_or_rs.auth_key = self.auth_key
@@ -214,7 +214,7 @@ class ShardedCluster(BaseModel):
             member['procParams']['configsvr'] = True
             if self.enable_ipv6:
                 common.enable_ipv6_single(member['procParams'])
-        rs_cfg['sslParams'] = self.sslParams
+        rs_cfg['sslParams'] = self.ssl_params
         self._configsvrs.append(ReplicaSets().create(rs_cfg))
 
     def __init_configsvrs(self, params):
@@ -229,7 +229,7 @@ class ShardedCluster(BaseModel):
             if self.enable_ipv6:
                 common.enable_ipv6_single(cfg)
             self._configsvrs.append(Servers().create(
-                'mongod', cfg, sslParams=self.sslParams, autostart=True,
+                'mongod', cfg, sslParams=self.ssl_params, autostart=True,
                 version=version, server_id=server_id))
 
     def __len__(self):
@@ -285,7 +285,7 @@ class ShardedCluster(BaseModel):
         params = self._strip_auth(params)
 
         self._routers.append(Servers().create(
-            'mongos', params, sslParams=self.sslParams, autostart=True,
+            'mongos', params, sslParams=self.ssl_params, autostart=True,
             version=version, server_id=server_id))
         return {'id': self._routers[-1], 'hostname': Servers().hostname(self._routers[-1])}
 
@@ -362,7 +362,7 @@ class ShardedCluster(BaseModel):
             rs_params = params.copy()
             # Turn 'rs_id' -> 'id', to be consistent with 'server_id' below.
             rs_params['id'] = rs_params.pop('rs_id', None)
-            rs_params.update({'sslParams': self.sslParams})
+            rs_params.update({'sslParams': self.ssl_params})
 
             rs_params['version'] = params.pop('version', self._version)
             rs_params['members'] = [
@@ -379,7 +379,7 @@ class ShardedCluster(BaseModel):
         else:
             # is single server
             params.setdefault('procParams', {})['shardsvr'] = True
-            params.update({'autostart': True, 'sslParams': self.sslParams})
+            params.update({'autostart': True, 'sslParams': self.ssl_params})
             params = params.copy()
             params['procParams'] = self._strip_auth(
                 params.get('procParams', {}))

--- a/mongo_orchestration/sharded_clusters.py
+++ b/mongo_orchestration/sharded_clusters.py
@@ -432,8 +432,8 @@ class ShardedCluster(BaseModel):
 
     def info(self):
         """return info about configuration"""
-        uri = ','.join(x['hostname'] for x in self.routers)
-        mongodb_uri = 'mongodb://' + uri
+        hosts = ','.join(x['hostname'] for x in self.routers)
+        mongodb_uri = self.mongodb_uri(hosts, [])
         result = {'id': self.id,
                   'shards': self.members,
                   'configsvrs': self.configsvrs,
@@ -441,7 +441,7 @@ class ShardedCluster(BaseModel):
                   'mongodb_uri': mongodb_uri,
                   'orchestration': 'sharded_clusters'}
         if self.login:
-            result['mongodb_auth_uri'] = self.mongodb_auth_uri(uri)
+            result['mongodb_auth_uri'] = self.mongodb_auth_uri(hosts, [])
         return result
 
     def cleanup(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,7 +44,7 @@ try:
     version_str = re.search('((\d+\.)+\d+)', info['version']).group(0)
     SERVER_VERSION = tuple(map(int, version_str.split('.')))
     # Do we have SSL support?
-    SSL_ENABLED = bool(info.get('OpenSSLVersion'))
+    SSL_ENABLED = bool(info.get('OpenSSLVersion')) or bool(info.get('openssl'))
 finally:
     Servers().cleanup()
 

--- a/tests/test_replica_sets.py
+++ b/tests/test_replica_sets.py
@@ -730,6 +730,12 @@ class ReplicaSetSSLTestCase(SSLTestCase):
             self.repl.primary(), ssl_certfile=certificate('client.pem'),
             ssl_cert_reqs=ssl.CERT_NONE))
 
+        # Check if mongodb_uri contains tls args
+        uri = self.server.info()['mongodb_uri']
+        self.assertIn(self.server.hostname, uri)
+        self.assertIn('tls=', uri)
+        self.assertIn('tlsCertificateKeyFile=', uri)
+
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):
             raise SkipTest("Need to be able to set 'authenticationMechanisms' "

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -459,6 +459,12 @@ class ServerSSLTestCase(SSLTestCase):
             self.server.hostname, ssl_certfile=certificate('client.pem'),
             ssl_cert_reqs=ssl.CERT_NONE))
 
+        # Check if mongodb_uri contains tls args
+        uri = self.server.info()['mongodb_uri']
+        self.assertIn(self.server.hostname, uri)
+        self.assertIn('tls=', uri)
+        self.assertIn('tlsCertificateKeyFile=', uri)
+
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):
             raise SkipTest("Need to be able to set 'authenticationMechanisms' "

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import operator
 import os
 import socket
@@ -34,6 +35,9 @@ from mongo_orchestration.process import PortPool
 from tests import (
     SkipTest, certificate, unittest, TEST_SUBJECT, SSLTestCase, SERVER_VERSION,
     TEST_RELEASES)
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 class ServerVersionTestCase(unittest.TestCase):

--- a/tests/test_sharded_clusters.py
+++ b/tests/test_sharded_clusters.py
@@ -710,6 +710,12 @@ class ShardSSLTestCase(SSLTestCase):
             pymongo.MongoClient(host, ssl_certfile=certificate('client.pem'),
                                 ssl_cert_reqs=ssl.CERT_NONE))
 
+        # Check if mongodb_uri contains tls args
+        uri = self.server.info()['mongodb_uri']
+        self.assertIn(self.server.hostname, uri)
+        self.assertIn('tls=', uri)
+        self.assertIn('tlsCertificateKeyFile=', uri)
+
     def test_mongodb_auth_uri(self):
         if SERVER_VERSION < (2, 4):
             raise SkipTest("Need to be able to set 'authenticationMechanisms' "


### PR DESCRIPTION
Fixes #268.

This PR refactors the generation of the URI returned after starting a cluster. Previously, `mongodb_uri` and `mongodb_auth_uri` had to be checked depending on whether auth was enabled. As indicated in the ticket above, TLS options also weren't added automatically. The goal is to get mongo-orchestration to return a `mongodb_uri` that can be used to connect to the cluster, without having to append other options.

This PR changes `mongodb_uri` to include both TLS and auth options. The `mongodb_auth_uri` field is kept for backward compatibility, but it always contains the same value as `mongodb_uri`. I'm not sure if this change is kosher, as somebody may be relying on `mongodb_uri` not containing auth information to test authentication failures. Please let me know if I should separate those changes.