### PR TITLE
feat(DRIVERS-1983): support loadBalancerPort in cli

### DIFF
--- a/mongo_orchestration/process.py
+++ b/mongo_orchestration/process.py
@@ -201,12 +201,13 @@ def repair_mongo(name, dbpath):
                     "check log file: %s" % (timeout, log_file))
 
 
-def mprocess(name, config_path, port=None, timeout=180):
+def mprocess(name, config_path, port=None, lb_port=None, timeout=180):
     """start 'name' process with params from config_path.
     Args:
         name - process name or path
         config_path - path to file where should be stored configuration
         port - process's port
+        lb_port - the mongos load balancer connection port
         timeout - specify how long, in seconds, a command can take before times out.
                   if timeout <=0 - doesn't wait for complete start process
     return tuple (Popen object, host) if process started, return (None, None) if not
@@ -214,7 +215,7 @@ def mprocess(name, config_path, port=None, timeout=180):
 
     logger.debug(
         "mprocess(name={name!r}, config_path={config_path!r}, port={port!r}, "
-                 "timeout={timeout!r})".format(**locals()))
+                 "lb_port={lb_port!r}, timeout={timeout!r})".format(**locals()))
     if not (config_path and isinstance(config_path, str) and os.path.exists(config_path)):
         raise OSError("can't find config file {config_path}".format(**locals()))
 
@@ -224,6 +225,8 @@ def mprocess(name, config_path, port=None, timeout=180):
     if cfg.get('port', None) is None or port:
         port = port or PortPool().port(check=True)
         cmd.extend(['--port', str(port)])
+    if lb_port:
+        cmd.extend(['--loadBalancerPort', str(lb_port)])
     host = "{host}:{port}".format(host=_host(), port=port)
     try:
         logger.debug("execute process: %s", ' '.join(cmd))

--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -177,6 +177,7 @@ class Server(BaseModel):
         self.proc = None # Popen object
         self.host = None  # hostname without port
         self.hostname = None  # string like host:port
+        self.lb_port = None # the load balancer port for mongos
         self.is_mongos = False
         self.kwargs = {}
         self.ssl_params = sslParams
@@ -193,6 +194,7 @@ class Server(BaseModel):
 
         elif proc_name.startswith('mongos'):
             self.is_mongos = True
+            self.lb_port = procParams.pop('loadBalancerPort', None)
             self.config_path, self.cfg = self.__init_mongos(procParams)
 
         else:
@@ -344,7 +346,7 @@ class Server(BaseModel):
 
             self.proc, self.hostname = process.mprocess(
                 self.name, self.config_path, self.cfg.get('port', None),
-                timeout)
+                self.lb_port, timeout)
             self.pid = self.proc.pid
             logger.debug("pid={pid}, hostname={hostname}".format(pid=self.pid, hostname=self.hostname))
             self.host = self.hostname.split(':')[0]

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -264,6 +264,12 @@ class ServerTestCase(unittest.TestCase):
         self.server2.stop()
         self.server2.cleanup()
 
+    def test_mongos_load_balancer_port(self):
+        self.server.cleanup()
+        self.server = Server('mongos', { 'loadBalancerPort': 27050 })
+        self.assertEqual(self.server.lb_port, 27050)
+        self.assertEqual(self.server.cfg.get('loadBalancerPort', None), None)
+
     def test_run_command(self):
         self.server.start(30)
 


### PR DESCRIPTION
Allows driver tools to provide a `loadBalancerPort` argument in the mongos `routers` config file which will translate into a `--loadBalancerPort` command line argument to the mongos if provided.

Not needed when https://jira.mongodb.org/browse/SERVER-62403 completed.