### PR TITLE
Use bottle server=auto by default to workaround cheroot install issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Usage
 ::
 
     mongo-orchestration [-h] [-f CONFIG] [-e ENV] [--no-fork] [-b BIND IP="localhost"] [-p PORT]
-                        [-s {cheroot,wsgiref}] [--socket-timeout-ms MILLIS]
+                        [-s {auto,cheroot,wsgiref}] [--socket-timeout-ms MILLIS]
                         [--pidfile PIDFILE] [--enable-majority-read-concern] {start,stop,restart}
 
 
@@ -73,7 +73,8 @@ Arguments:
    file
 -  **--no-fork** - run server in foreground
 -  **-b, --bind** - host on which Mongo Orchestration and subordinate mongo processes should listen for requests. Defaults to "localhost".
--  **-s, --server** - HTTP backend to use: one of `cheroot` or `wsgiref`
+-  **-s, --server** - HTTP backend to use: one of `auto`, `cheroot`, or `wsgiref`. `auto`
+   configures bottle to automatically choose an available backend.
 -  **-p** - port number (8889 by default)
 -  **--socket-timeout-ms** - socket timeout when connecting to MongoDB servers
 -  **--pidfile** - location where mongo-orchestration should place its pid file
@@ -228,7 +229,7 @@ Changelog
 Changes in Version 0.7.1 (TBD)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Replaced dependency on CherryPy with cheroot. `-s cheroot` is the new default
+- Replaced dependency on CherryPy with cheroot. `-s auto` is the new default
   and `-s cherrypy` is no longer supported.
 
 Changes in Version 0.7.0 (2021-04-06)

--- a/mongo_orchestration/common.py
+++ b/mongo_orchestration/common.py
@@ -31,7 +31,7 @@ LOGGING_FORMAT = '%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s'
 
 DEFAULT_BIND = os.environ.get('MO_HOST', 'localhost')
 DEFAULT_PORT = int(os.environ.get('MO_PORT', '8889'))
-DEFAULT_SERVER = 'cheroot'
+DEFAULT_SERVER = 'auto'
 DEFAULT_SOCKET_TIMEOUT = 20000  # 20 seconds.
 
 # Username for included client x509 certificate.

--- a/mongo_orchestration/server.py
+++ b/mongo_orchestration/server.py
@@ -54,7 +54,7 @@ def read_env():
                         default=False)
     parser.add_argument('-s', '--server',
                         action='store', dest='server', type=str,
-                        default=DEFAULT_SERVER, choices=('cheroot', 'wsgiref'))
+                        default=DEFAULT_SERVER, choices=('auto', 'cheroot', 'wsgiref'))
     parser.add_argument('--version', action='version',
                         version='Mongo Orchestration v' + __version__)
     parser.add_argument('--socket-timeout-ms', action='store',


### PR DESCRIPTION
The changes in https://github.com/10gen/mongo-orchestration/pull/293 ran into this pip(?) bug on python2.7:
```
New python executable in /data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/python2
Also creating executable in /data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
Running virtualenv with interpreter /usr/bin/python2
Collecting https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz
  Using cached https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz
Collecting bottle>=0.12.7 (from mongo-orchestration==0.7.1.dev0)
Collecting cheroot>=5.11 (from mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/d3/87/8c5a471a82dfd1c82b4cb6605fcad90e1f0e938b14c0516da3504701a2b4/cheroot-8.6.0-py2.py3-none-any.whl
Collecting pymongo<4,>=3.6 (from mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/6f/a3/3af16e90f34a90837ff4fe0f52cda602b5ec208307b05927d038d1af0b11/pymongo-3.13.0-cp27-cp27mu-manylinux1_x86_64.whl
Collecting more-itertools<8.11.0,>=2.6; python_version < "3.6" (from cheroot>=5.11->mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/2f/9d/dcfe59e213093695f108508af1214cf9cd95cc5489e46877ec5cb56369e5/more_itertools-5.0.0-py2-none-any.whl
Collecting selectors2; python_version < "3.4" (from cheroot>=5.11->mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/9a/4f/ea16bdfb793550c472ca4f2035337a3e90f31c1fe3f8d1a9227cd8b5542e/selectors2-2.0.2-py2.py3-none-any.whl
Collecting backports.functools-lru-cache; python_version < "3.3" (from cheroot>=5.11->mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/e5/c1/1a48a4bb9b515480d6c666977eeca9243be9fa9e6fb5a34be0ad9627f737/backports.functools_lru_cache-1.6.4-py2.py3-none-any.whl
Requirement already satisfied, skipping upgrade: six>=1.11.0 in /usr/lib/python2.7/dist-packages (from cheroot>=5.11->mongo-orchestration==0.7.1.dev0) (1.12.0)
Collecting jaraco.functools (from cheroot>=5.11->mongo-orchestration==0.7.1.dev0)
  Using cached https://files.pythonhosted.org/packages/12/a4/3e7366d0f5e75dcad7be88524c8cbd0f3a9fb1db243269550981740c57fe/jaraco.functools-2.0-py2.py3-none-any.whl
Building wheels for collected packages: mongo-orchestration
  Running setup.py bdist_wheel for mongo-orchestration: started
  Running setup.py bdist_wheel for mongo-orchestration: finished with status 'done'
  Stored in directory: /data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/tmp/pip-ephem-wheel-cache-k3u_H0/wheels/a2/26/9c/b435e053fe351186f9b4dd4b44549452dd4783df4d82befeb6
Successfully built mongo-orchestration
Installing collected packages: bottle, more-itertools, selectors2, backports.functools-lru-cache, jaraco.functools, cheroot, pymongo, mongo-orchestration
  Found existing installation: pymongo 3.5.1
    Not uninstalling pymongo at /usr/local/lib/python2.7/dist-packages, outside environment /data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv
    Can't uninstall 'pymongo'. No files were found to uninstall.
Successfully installed backports.functools-lru-cache-1.6.4 bottle-0.12.23 cheroot-8.6.0 jaraco.functools-2.0 mongo-orchestration-0.7.1.dev0 more-itertools-5.0.0 pymongo-3.13.0 selectors2-2.0.2
Package                       Version
----------------------------- -----------
bottle                        0.12.23
cheroot                       8.6.0
backports.functools-lru-cache 1.6.4
pip                           18.1
setuptools                    40.8.0
wheel                         0.32.3
...
/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools
Cloning into 'drivers-evergreen-tools'...
./.evergreen/start-orchestration.sh: 69: ./.evergreen/start-orchestration.sh: lsof: not found
total 16
drwxr-xr-x 6 admin admin  145 Dec 16 16:52 .
drwxr-xr-x 9 admin admin 4096 Dec 16 16:52 ..
drwxr-xr-x 5 admin admin   65 Dec 16 16:52 configs
drwxr-xr-x 2 admin admin   20 Dec 16 16:52 db
drwxr-xr-x 2 admin admin   24 Dec 16 16:52 lib
-rw-r--r-- 1 admin admin  111 Dec 16 16:52 orchestration.config
-rw-r--r-- 1 admin admin    0 Dec 16 16:52 out.log
-rw-r--r-- 1 admin admin   64 Dec 16 16:52 require-api-version.js
-rw-r--r-- 1 admin admin   40 Dec 16 16:52 server.log
drwxr-xr-x 7 admin admin   69 Dec 16 16:52 venv
Failed to start mongo-orchestration, see /data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/out.log:
Preparing to start mongo-orchestration daemon
Preparing to start mongo-orchestration daemon
Starting Mongo Orchestration on port 8889...
Traceback (most recent call last):
  File "/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/local/lib/python2.7/site-packages/mongo_orchestration/server.py", line 134, in run
    server=self.args.server)
  File "/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/bottle.py", line 3172, in run
    server.run(app)
  File "/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/bottle.py", line 2833, in run
    from cheroot import wsgi
  File "/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/local/lib/python2.7/site-packages/cheroot/wsgi.py", line 36, in <module>
    from . import server
  File "/data/mci/1c7348b3c684cf6ec8cbb663f3ecad62/drivers-evergreen-tools/.evergreen/orchestration/venv/local/lib/python2.7/site-packages/cheroot/server.py", line 87, in <module>
    from backports.functools_lru_cache import lru_cache
ImportError: No module named functools_lru_cache
```

This change works around the issue by using bottle's auto server which catches the ImportError and fallsback to the next available backend (in this case wsgiref). Tested like this:
```
$ python -m pip uninstall backports.functools_lru_cache
Found existing installation: backports.functools-lru-cache 1.6.4
Uninstalling backports.functools-lru-cache-1.6.4:
  Would remove:
    /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports.functools_lru_cache-1.6.4.dist-info/*
    /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/*
Proceed (y/n)? y
  Successfully uninstalled backports.functools-lru-cache-1.6.4
$ python -m mongo_orchestration.server start --no-fork -s cheroot
Starting Mongo Orchestration on port 8889...
Bottle v0.12.23 server starting up (using CherootServer())...
Listening on http://localhost:8889/
Hit Ctrl-C to quit.

Traceback (most recent call last):
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/server.py", line 134, in run
    server=self.args.server)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/bottle.py", line 3172, in run
    server.run(app)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/bottle.py", line 2833, in run
    from cheroot import wsgi
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cheroot/wsgi.py", line 36, in <module>
    from . import server
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cheroot/server.py", line 87, in <module>
    from backports.functools_lru_cache import lru_cache
ImportError: No module named backports.functools_lru_cache
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/server.py", line 189, in <module>
    main()
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/server.py", line 183, in main
    daemon.run()
  File "/Users/shane/git/mongo-orchestration/mongo_orchestration/server.py", line 134, in run
    server=self.args.server)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/bottle.py", line 3172, in run
    server.run(app)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/bottle.py", line 2833, in run
    from cheroot import wsgi
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cheroot/wsgi.py", line 36, in <module>
    from . import server
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cheroot/server.py", line 87, in <module>
    from backports.functools_lru_cache import lru_cache
ImportError: No module named backports.functools_lru_cache

$  python -m mongo_orchestration.server start --no-fork # With new default -s=auto
Starting Mongo Orchestration on port 8889...
Bottle v0.12.23 server starting up (using AutoServer())...
Listening on http://localhost:8889/
Hit Ctrl-C to quit.

^C%                                                                                                            
```