### PR TITLE
Allow python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ Changes in Version 0.8.0 (TBD)
 
 - Upgrade to PyMongo 4.x and set up GitHub Actions testing.
 - Remove support for managing MongoDB 3.4 or earlier servers.
-- Remove support for Python 3.6 or earlier.
+- Remove support for Python 3.7 or earlier.
 - Replaced dependency on CherryPy with cheroot. `-s auto` is the new default
   and `-s cherrypy` is no longer supported.
 - Remove transactionLifetimeLimitSeconds default.

--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ Changes in Version 0.8.0 (TBD)
 
 - Upgrade to PyMongo 4.x and set up GitHub Actions testing.
 - Remove support for managing MongoDB 3.4 or earlier servers.
-- Remove support for Python 3.7 or earlier.
+- Remove support for Python 3.5 or earlier.
 - Replaced dependency on CherryPy with cheroot. `-s auto` is the new default
   and `-s cherrypy` is no longer supported.
 - Remove transactionLifetimeLimitSeconds default.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=['pymongo>=4,<5',
                       'bottle>=0.12.7',
                       'cheroot>=5.11'],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     tests_require=['coverage>=3.5'],
     packages=find_packages(exclude=('tests',)),
     package_data={
@@ -47,6 +47,7 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Address failure seen in https://evergreen.mongodb.com/task/mongosync_rhel70_e2e_unlike_sc2_sc3_60_4ee9b6161588135f2bcbe945f7ae8ae62369a75e_23_03_14_22_06_01.  PyMongo 4.0.x is compatible with Python 3.6, so we should allow it.  