### PR TITLE
Remove 'journal' options for newer mongod (>=6.1)

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -85,6 +85,14 @@ class Server(BaseModel):
                 params.setdefault('writePeriodicNoops', 1)
             config['setParameter'] = params
 
+        # no 'journal' after 6.1 onwards...
+        # https://www.mongodb.com/docs/manual/reference/program/mongod/#options
+        if self.version >= (6, 1):
+            if config.get('journal'):
+                config.pop('journal')
+            if config.get('nojournal'):
+                config.pop('nojournal')
+
         compressors = config.get('networkMessageCompressors')
         if compressors is None:
             if self.version >= (4, 1, 7):


### PR DESCRIPTION
Newer versions of `mongod` don't recognize `journal` options as valid since it's always in journaling mode.
So `mongo-orchestration start` command would fail with default start up with 6.x and 7.x.

This patch takes care of the issue with a backwards-compatible approach :blush: 