### PR TITLE
SERVER-84801 fix handling of enableMajorityReadConcern

### DIFF
--- a/mongo_orchestration/servers.py
+++ b/mongo_orchestration/servers.py
@@ -128,11 +128,15 @@ class Server(BaseModel):
         self.__init_config_params(cfg)
 
         # Read concern majority requires MongoDB >= 3.2, WiredTiger storage
-        # engine, and protocol version 1:
+        # engine, and protocol version 1.
+        # Starting in MongoDB 5.0, enableMajorityReadConcern and --enableMajorityReadConcern 
+        # cannot be changed and are always set to true due to storage engine improvements.
+        # The flag is removed altogether in MongoDB 8.1.
         # https://docs.mongodb.com/manual/reference/read-concern/
         if ('enableMajorityReadConcern' not in cfg
                 and self.enable_majority_read_concern
-                and self.version >= (3, 2)):
+                and self.version >= (3, 2)
+                and self.version < (5, 0)):
             if (cfg.get('storageEngine', 'wiredTiger') == 'wiredTiger'
                     and cfg.get('protocolVersion', 1) == 1):
                 cfg['enableMajorityReadConcern'] = True

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -219,7 +219,7 @@ class ServersTestCase(unittest.TestCase):
                                    .get('parsed', {})
                                    .get('replication', {})
                                    .get('enableMajorityReadConcern'))
-            if SERVER_VERSION >= (3, 2):
+            if SERVER_VERSION >= (3, 2) and SERVER_VERSION < (5, 0):
                 self.assertTrue(majority_rc_enabled)
             else:
                 self.assertFalse(majority_rc_enabled)


### PR DESCRIPTION
Testing with drivers-evergreen-tools in this [patch](https://spruce.mongodb.com/version/665f302281c7ff0007041f6e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).