### PR TITLE
Add MCP server for managing MongoDB clusters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,60 @@ with minimal configuration.
     mongo-orchestration start
     mongo-launch replica ssl auth
 
+MCP Server
+----------
+
+Mongo Orchestration ships an `MCP (Model Context Protocol) <https://modelcontextprotocol.io>`__
+server that exposes three tools to AI assistants (e.g. Claude Code):
+
+-  **start_cluster** - start a standalone mongod, replica set, or sharded cluster
+-  **stop_cluster** - stop a cluster by ID
+-  **list_clusters** - list all running clusters with their URIs
+
+The MCP server starts ``mongo-orchestration`` automatically if it is not
+already running.
+
+Configuration
+~~~~~~~~~~~~~
+
+Register the server globally in Claude Code by adding the following to
+``~/.claude.json``::
+
+    "mcpServers": {
+        "mongo-launch": {
+            "type": "stdio",
+            "command": "/path/to/venv/bin/python",
+            "args": ["-m", "mongo_orchestration.mcp_server"]
+        }
+    }
+
+Multi-version support
+~~~~~~~~~~~~~~~~~~~~~
+
+To start clusters using specific MongoDB versions, create a
+``mo-config.json`` file at the root of the project and map version
+labels to binary directories::
+
+    {
+        "releases": {
+            "4.4": "/path/to/mongodb-4.4/bin",
+            "7.0": "/path/to/mongodb-7.0/bin",
+            "8.2": "/path/to/mongodb-8.2/bin"
+        }
+    }
+
+When this file is present, ``mongo-orchestration-mcp`` picks it up
+automatically on startup. You can also use
+`m <https://github.com/aheckmann/m>`__ as a MongoDB version manager and
+point each release to ``~/.local/m/versions/<version>/bin``.
+
+Standalone entry point
+~~~~~~~~~~~~~~~~~~~~~~
+
+The MCP server can also be started directly::
+
+    mongo-orchestration-mcp
+
 Tests
 -----
 

--- a/mongo_orchestration/mcp_server.py
+++ b/mongo_orchestration/mcp_server.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# Copyright 2026-Present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCP server for mongo-orchestration (stdio transport).
+
+Claude Code launches this process on demand via the stdio MCP config.
+On startup, it ensures mongo-orchestration is running (starts it if not).
+Tools communicate with mongo-orchestration via its REST API (localhost:8889).
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
+
+_MO_HOST = os.environ.get("MO_HOST", "localhost")
+_MO_PORT = int(os.environ.get("MO_PORT", "8889"))
+_MO_URL = f"http://{_MO_HOST}:{_MO_PORT}"
+
+# Path to the mongo-orchestration binary installed in the same venv as us.
+_MO_BIN = os.path.join(os.path.dirname(sys.executable), "mongo-orchestration")
+
+mcp = FastMCP("mongo-orchestration")
+
+
+# -------------------------------------------------------------------
+# Internal helpers
+# -------------------------------------------------------------------
+
+def _is_up(timeout: float = 2.0) -> bool:
+    try:
+        conn = socket.create_connection((_MO_HOST, _MO_PORT), timeout=timeout)
+        conn.close()
+        return True
+    except OSError:
+        return False
+
+
+def _ensure_running() -> str | None:
+    """Start mongo-orchestration if it is not already up.
+
+    Returns an error message on failure, None on success.
+    """
+    if _is_up():
+        return None
+
+    bin_path = _MO_BIN if os.path.exists(_MO_BIN) else "mongo-orchestration"
+
+    # Look for mo-config.json next to this package or in the project root.
+    _here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    _config = os.path.join(_here, "mo-config.json")
+    cmd = [bin_path, "start"]
+    if os.path.exists(_config):
+        cmd += ["-f", _config]
+
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            timeout=30,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        return (
+            "mongo-orchestration not found. "
+            f"Expected: {_MO_BIN}"
+        )
+    except subprocess.CalledProcessError as exc:
+        return f"Failed to start mongo-orchestration: {exc.stderr}"
+    except subprocess.TimeoutExpired:
+        return "Timeout while starting mongo-orchestration."
+
+    # Wait up to 10 s for the server to accept connections.
+    for _ in range(10):
+        if _is_up():
+            return None
+        time.sleep(1)
+
+    return f"mongo-orchestration started but not reachable on {_MO_HOST}:{_MO_PORT}."
+
+
+def _get(path: str) -> dict:
+    import requests
+    return requests.get(f"{_MO_URL}/{path}", timeout=10).json()
+
+
+def _post(path: str, body: dict) -> dict:
+    import requests
+    r = requests.post(f"{_MO_URL}/{path}", json=body, timeout=None)
+    if not r.ok:
+        raise RuntimeError(r.text)
+    return r.json()
+
+
+def _delete(path: str) -> None:
+    import requests
+    requests.delete(f"{_MO_URL}/{path}", timeout=30)
+
+
+# -------------------------------------------------------------------
+# Tools
+# -------------------------------------------------------------------
+
+@mcp.tool()
+def start_cluster(
+    cluster_type: Literal["single", "repl", "shard"] = "single",
+    version: str = "",
+    auth: bool = False,
+    ssl: bool = False,
+    single_member: bool = False,
+) -> str:
+    """Start a MongoDB cluster via mongo-orchestration.
+
+    Starts mongo-orchestration automatically if it is not running.
+
+    Args:
+        cluster_type: "single" (standalone mongod), "repl" (replica set),
+                      or "shard" (sharded cluster with one replica-set shard).
+        version: MongoDB version, e.g. "7.0" or "latest". Empty = server default.
+        auth: Enable authentication (login=user / password=password).
+        ssl: Enable SSL/TLS.
+        single_member: For replica sets, use a 1-member set instead of 3.
+    """
+    err = _ensure_running()
+    if err:
+        return f"Error: {err}"
+
+    base: dict = {}
+    if version:
+        base["version"] = version
+    if auth:
+        base["login"] = "user"
+        base["password"] = "password"
+        base["auth_key"] = "secret"
+
+    try:
+        if cluster_type == "single":
+            body = {**base, "name": "mongod", "procParams": {}}
+            result = _post("servers", body)
+            uid = result["id"]
+            uri = result.get("mongodb_auth_uri") or result.get("mongodb_uri", "")
+            return f"Standalone mongod started.\n  id:  {uid}\n  uri: {uri}"
+
+        elif cluster_type == "repl":
+            n = 1 if single_member else 3
+            members = [{"procParams": {}} for _ in range(n)]
+            body = {**base, "members": members}
+            result = _post("replica_sets", body)
+            uid = result["id"]
+            uri = result.get("mongodb_auth_uri") or result.get("mongodb_uri", "")
+            return (
+                f"Replica set started ({n} member(s)).\n"
+                f"  id:  {uid}\n"
+                f"  uri: {uri}"
+            )
+
+        elif cluster_type == "shard":
+            n = 1 if single_member else 3
+            members = [{"procParams": {}} for _ in range(n)]
+            body = {
+                **base,
+                "configsvrs": [{}],
+                "routers": [{}],
+                "shards": [{"id": "shard-0", "shardParams": {"members": members}}],
+            }
+            result = _post("sharded_clusters", body)
+            uid = result["id"]
+            uri = result.get("mongodb_auth_uri") or result.get("mongodb_uri", "")
+            return f"Sharded cluster started.\n  id:  {uid}\n  uri: {uri}"
+
+        else:
+            return f"Unknown cluster_type '{cluster_type}'. Use: single, repl, or shard."
+
+    except Exception as exc:
+        return f"Error starting {cluster_type}: {exc}"
+
+
+@mcp.tool()
+def stop_cluster(cluster_id: str) -> str:
+    """Stop and remove a running cluster by its ID.
+
+    Args:
+        cluster_id: The ID returned by start_cluster or list_clusters.
+    """
+    err = _ensure_running()
+    if err:
+        return f"Error: {err}"
+
+    for resource in ("servers", "replica_sets", "sharded_clusters"):
+        try:
+            ids = [item["id"] for item in _get(resource).get(resource, [])]
+        except Exception:
+            continue
+        if cluster_id in ids:
+            try:
+                _delete(f"{resource}/{cluster_id}")
+                return f"'{cluster_id}' stopped."
+            except Exception as exc:
+                return f"Error stopping '{cluster_id}': {exc}"
+
+    return f"No cluster found with id '{cluster_id}'. Use list_clusters to see running clusters."
+
+
+@mcp.tool()
+def list_clusters() -> str:
+    """List all clusters currently managed by mongo-orchestration."""
+    err = _ensure_running()
+    if err:
+        return f"mongo-orchestration is not running: {err}"
+
+    lines: list[str] = []
+    labels = {
+        "servers": "Standalone servers",
+        "replica_sets": "Replica sets",
+        "sharded_clusters": "Sharded clusters",
+    }
+    try:
+        for resource, label in labels.items():
+            items = _get(resource).get(resource, [])
+            if items:
+                lines.append(f"{label}:")
+                for item in items:
+                    uid = item.get("id", "?")
+                    lines.append(f"  {uid}")
+    except Exception as exc:
+        return f"Error: {exc}"
+
+    return "\n".join(lines) if lines else "No clusters running."
+
+
+# -------------------------------------------------------------------
+# Entry point
+# -------------------------------------------------------------------
+
+def main() -> None:
+    """Start the MCP server (stdio). Ensures mongo-orchestration is running first."""
+    _ensure_running()
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
 [project.scripts]
 mongo-launch = "mongo_orchestration.launch:main"
 mongo-orchestration = "mongo_orchestration.server:main"
+mongo-orchestration-mcp = "mongo_orchestration.mcp_server:main"
 
 [project.urls]
 Homepage = "https://github.com/10gen/mongo-orchestration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp>=1.0",
+]
 test = [
     "coverage>=3.5",
+    "mcp>=1.0",
     "pexpect",
     "pytest",
 ]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,352 @@
+#!/usr/bin/python
+# coding=utf-8
+# Copyright 2026-Present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the MCP server tools (mongo_orchestration/mcp_server.py).
+
+All HTTP calls and _ensure_running are mocked so no MongoDB binary or
+running mongo-orchestration instance is required.
+"""
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import mongo_orchestration.mcp_server as mcp_server
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mo_up():
+    """Patch _ensure_running to simulate mongo-orchestration already running."""
+    return patch.object(mcp_server, "_ensure_running", return_value=None)
+
+
+def _get_side_effect(**resources):
+    """Return a _get side-effect that maps resource name → list of items."""
+    def _get(path):
+        return {path: resources.get(path, [])}
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# start_cluster
+# ---------------------------------------------------------------------------
+
+class TestStartClusterSingle(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "srv1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_returns_id_and_uri(self, mock_post):
+        result = mcp_server.start_cluster(cluster_type="single")
+        self.assertIn("srv1", result)
+        self.assertIn("mongodb://localhost:27017", result)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "srv1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_post_path_and_name(self, mock_post):
+        mcp_server.start_cluster(cluster_type="single")
+        path, body = mock_post.call_args[0]
+        self.assertEqual(path, "servers")
+        self.assertEqual(body["name"], "mongod")
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "srv1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_version_forwarded(self, mock_post):
+        mcp_server.start_cluster(cluster_type="single", version="7.0")
+        _, body = mock_post.call_args[0]
+        self.assertEqual(body["version"], "7.0")
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "srv1",
+                                "mongodb_auth_uri": "mongodb://user:password@localhost:27017",
+                                "mongodb_uri": "mongodb://localhost:27017"})
+    def test_auth_sets_credentials(self, mock_post):
+        result = mcp_server.start_cluster(cluster_type="single", auth=True)
+        _, body = mock_post.call_args[0]
+        self.assertEqual(body["login"], "user")
+        self.assertEqual(body["password"], "password")
+        self.assertIn("auth_key", body)
+        # auth URI takes precedence in the output
+        self.assertIn("user:password", result)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "srv1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_no_version_key_when_empty(self, mock_post):
+        mcp_server.start_cluster(cluster_type="single", version="")
+        _, body = mock_post.call_args[0]
+        self.assertNotIn("version", body)
+
+
+class TestStartClusterRepl(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "rs1", "mongodb_uri": "mongodb://localhost:27017/?replicaSet=rs1"})
+    def test_default_3_members(self, mock_post):
+        result = mcp_server.start_cluster(cluster_type="repl")
+        _, body = mock_post.call_args[0]
+        self.assertEqual(len(body["members"]), 3)
+        self.assertIn("3 member", result)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "rs1", "mongodb_uri": "mongodb://localhost:27017/?replicaSet=rs1"})
+    def test_single_member(self, mock_post):
+        result = mcp_server.start_cluster(cluster_type="repl", single_member=True)
+        _, body = mock_post.call_args[0]
+        self.assertEqual(len(body["members"]), 1)
+        self.assertIn("1 member", result)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "rs1", "mongodb_uri": "mongodb://localhost:27017/?replicaSet=rs1"})
+    def test_post_path(self, mock_post):
+        mcp_server.start_cluster(cluster_type="repl")
+        path, _ = mock_post.call_args[0]
+        self.assertEqual(path, "replica_sets")
+
+
+class TestStartClusterShard(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "sh1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_body_has_required_keys(self, mock_post):
+        mcp_server.start_cluster(cluster_type="shard")
+        _, body = mock_post.call_args[0]
+        self.assertIn("configsvrs", body)
+        self.assertIn("routers", body)
+        self.assertIn("shards", body)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "sh1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_routers_have_no_procparams(self, mock_post):
+        # routers must be [{}], not [{"procParams": {}}] — the latter would
+        # write "procParams={}" literally into the mongos config file.
+        mcp_server.start_cluster(cluster_type="shard")
+        _, body = mock_post.call_args[0]
+        for router in body["routers"]:
+            self.assertNotIn("procParams", router)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "sh1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_post_path(self, mock_post):
+        mcp_server.start_cluster(cluster_type="shard")
+        path, _ = mock_post.call_args[0]
+        self.assertEqual(path, "sharded_clusters")
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "sh1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_shard_member_count(self, mock_post):
+        mcp_server.start_cluster(cluster_type="shard")
+        _, body = mock_post.call_args[0]
+        members = body["shards"][0]["shardParams"]["members"]
+        self.assertEqual(len(members), 3)
+
+    @patch.object(mcp_server, "_post",
+                  return_value={"id": "sh1", "mongodb_uri": "mongodb://localhost:27017"})
+    def test_single_member_shard(self, mock_post):
+        mcp_server.start_cluster(cluster_type="shard", single_member=True)
+        _, body = mock_post.call_args[0]
+        members = body["shards"][0]["shardParams"]["members"]
+        self.assertEqual(len(members), 1)
+
+
+class TestStartClusterErrors(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    def test_unknown_cluster_type(self):
+        result = mcp_server.start_cluster(cluster_type="unknown")
+        self.assertIn("Unknown cluster_type", result)
+
+    def test_mo_not_running(self):
+        with patch.object(mcp_server, "_ensure_running", return_value="connection refused"):
+            result = mcp_server.start_cluster()
+        self.assertIn("Error", result)
+
+    @patch.object(mcp_server, "_post", side_effect=RuntimeError("timeout"))
+    def test_post_exception_returns_error(self, _):
+        result = mcp_server.start_cluster(cluster_type="single")
+        self.assertIn("Error", result)
+
+
+# ---------------------------------------------------------------------------
+# stop_cluster
+# ---------------------------------------------------------------------------
+
+class TestStopCluster(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    @patch.object(mcp_server, "_delete")
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(servers=[{"id": "srv1"}]))
+    def test_stop_standalone(self, _get, mock_delete):
+        result = mcp_server.stop_cluster("srv1")
+        self.assertIn("stopped", result)
+        mock_delete.assert_called_once_with("servers/srv1")
+
+    @patch.object(mcp_server, "_delete")
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(replica_sets=[{"id": "rs1"}]))
+    def test_stop_replica_set(self, _get, mock_delete):
+        result = mcp_server.stop_cluster("rs1")
+        self.assertIn("stopped", result)
+        mock_delete.assert_called_once_with("replica_sets/rs1")
+
+    @patch.object(mcp_server, "_delete")
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(sharded_clusters=[{"id": "sh1"}]))
+    def test_stop_sharded_cluster(self, _get, mock_delete):
+        result = mcp_server.stop_cluster("sh1")
+        self.assertIn("stopped", result)
+        mock_delete.assert_called_once_with("sharded_clusters/sh1")
+
+    @patch.object(mcp_server, "_get", side_effect=_get_side_effect())
+    def test_stop_not_found(self, _):
+        result = mcp_server.stop_cluster("nonexistent")
+        self.assertIn("No cluster found", result)
+
+    def test_stop_mo_not_running(self):
+        with patch.object(mcp_server, "_ensure_running", return_value="connection refused"):
+            result = mcp_server.stop_cluster("srv1")
+        self.assertIn("Error", result)
+
+
+# ---------------------------------------------------------------------------
+# list_clusters
+# ---------------------------------------------------------------------------
+
+class TestListClusters(unittest.TestCase):
+
+    def setUp(self):
+        self._mo = _mo_up()
+        self._mo.start()
+
+    def tearDown(self):
+        self._mo.stop()
+
+    @patch.object(mcp_server, "_get", side_effect=_get_side_effect())
+    def test_empty(self, _):
+        result = mcp_server.list_clusters()
+        self.assertEqual(result, "No clusters running.")
+
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(servers=[{"id": "srv1"}]))
+    def test_lists_standalone(self, _):
+        result = mcp_server.list_clusters()
+        self.assertIn("srv1", result)
+        self.assertIn("Standalone", result)
+
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(replica_sets=[{"id": "rs1"}, {"id": "rs2"}]))
+    def test_lists_multiple_replica_sets(self, _):
+        result = mcp_server.list_clusters()
+        self.assertIn("rs1", result)
+        self.assertIn("rs2", result)
+        self.assertIn("Replica", result)
+
+    @patch.object(mcp_server, "_get",
+                  side_effect=_get_side_effect(
+                      servers=[{"id": "srv1"}],
+                      sharded_clusters=[{"id": "sh1"}]))
+    def test_lists_mixed(self, _):
+        result = mcp_server.list_clusters()
+        self.assertIn("srv1", result)
+        self.assertIn("sh1", result)
+
+    def test_mo_not_running(self):
+        with patch.object(mcp_server, "_ensure_running", return_value="connection refused"):
+            result = mcp_server.list_clusters()
+        self.assertIn("not running", result)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_running
+# ---------------------------------------------------------------------------
+
+class TestEnsureRunning(unittest.TestCase):
+
+    @patch.object(mcp_server, "_is_up", return_value=True)
+    def test_already_up(self, _):
+        self.assertIsNone(mcp_server._ensure_running())
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    @patch.object(mcp_server, "_is_up", side_effect=[False] + [True])
+    def test_starts_mo_when_down(self, _is_up, mock_run, _sleep):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = mcp_server._ensure_running()
+        self.assertIsNone(result)
+        mock_run.assert_called_once()
+
+    @patch("time.sleep")
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    @patch.object(mcp_server, "_is_up", return_value=False)
+    def test_binary_not_found(self, _is_up, _run, _sleep):
+        result = mcp_server._ensure_running()
+        self.assertIsNotNone(result)
+        self.assertIn("not found", result)
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    @patch.object(mcp_server, "_is_up", return_value=False)
+    def test_never_becomes_reachable(self, _is_up, mock_run, _sleep):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = mcp_server._ensure_running()
+        self.assertIsNotNone(result)
+        self.assertIn("not reachable", result)
+
+    @patch("time.sleep")
+    @patch("subprocess.run", side_effect=__import__('subprocess').TimeoutExpired(cmd=[], timeout=30))
+    @patch.object(mcp_server, "_is_up", return_value=False)
+    def test_timeout(self, _is_up, _run, _sleep):
+        result = mcp_server._ensure_running()
+        self.assertIsNotNone(result)
+        self.assertIn("Timeout", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `mongo_orchestration/mcp_server.py`: an MCP (Model Context Protocol) server that exposes three tools to AI assistants (e.g. Claude Code): `start_cluster`, `stop_cluster`, and `list_clusters`.
- The MCP server uses stdio transport and auto-starts `mongo-orchestration` if it is not already running.
- Multi-version support via `mo-config.json`: map version labels to MongoDB binary directories (compatible with the `m` version manager).
- Add `mongo-orchestration-mcp` entry point in `pyproject.toml`.
- Document the MCP server in `README.rst`.

<img width="2252" height="1514" alt="image" src="https://github.com/user-attachments/assets/f79889c5-9046-49df-ac28-d9d308927f52" />

## Why an MCP server rather than a prompt skill?

The primary use case is **driver and library development against MongoDB**: a developer asks an AI assistant to run a test suite against a specific topology and version, and the assistant needs to manage clusters autonomously as part of a larger task.

A prompt skill (e.g. `/mongo-launch`) requires the user to explicitly invoke each step. An MCP server exposes structured tools that the AI can call on its own initiative mid-task:

1. Understand from context which topology and version are needed (e.g. replica set, MongoDB 7.0 with auth).
2. Call `start_cluster` to provision the cluster and obtain the connection URI.
3. Run the tests using that URI.
4. Call `stop_cluster` to clean up.

This end-to-end flow — provision → test → teardown — happens without manual intervention, which is exactly what MCP tools are designed for. A skill would require the user to orchestrate each step themselves.

## Test plan

- [ ] Install the package in a virtualenv and verify `mongo-orchestration-mcp` is on the PATH.
- [ ] Register the MCP server in `~/.claude.json` and verify Claude Code lists the three tools.
- [ ] Call `start_cluster` with `cluster_type="single"`, `"repl"`, and `"shard"` and verify each cluster starts and returns a connection URI.
- [ ] Call `list_clusters` and verify all running clusters appear.
- [ ] Call `stop_cluster` for each running cluster and verify they stop cleanly.
- [ ] Create a `mo-config.json` with version paths and verify `start_cluster(version="7.0")` starts the correct binary.
- [ ] Verify `_ensure_running()` starts `mongo-orchestration` automatically when not already running.